### PR TITLE
hotfix: 환불 승인에 따른 정산 데이터 수정되도록 변경

### DIFF
--- a/groble-application/src/main/java/liaison/groble/application/admin/service/AdminOrderService.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/service/AdminOrderService.java
@@ -11,6 +11,8 @@ import liaison.groble.application.admin.dto.AdminOrderCancelRequestDTO;
 import liaison.groble.application.admin.dto.AdminOrderCancellationReasonDTO;
 import liaison.groble.application.admin.dto.AdminOrderSummaryInfoDTO;
 import liaison.groble.application.order.service.OrderReader;
+import liaison.groble.application.payment.dto.cancel.PaymentCancelResponse;
+import liaison.groble.application.payment.service.PayplePaymentFacade;
 import liaison.groble.application.payment.service.PayplePaymentService;
 import liaison.groble.application.purchase.service.PurchaseReader;
 import liaison.groble.common.response.PageResponse;
@@ -28,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AdminOrderService {
   private final OrderReader orderReader;
   private final PayplePaymentService payplePaymentService;
+  private final PayplePaymentFacade payplePaymentFacade;
   private final OrderRepository orderRepository;
   private final PurchaseReader purchaseReader;
 
@@ -77,27 +80,17 @@ public class AdminOrderService {
     if ("approve".equalsIgnoreCase(action)) {
       // 취소 승인 - 페이플 실결제 취소 API 호출
       try {
-        // 페이플 인증 정보 획득
-        var authResponse = payplePaymentService.getPaymentAuthForCancel();
-
-        // 결제 취소 처리
-        var cancelResult =
-            payplePaymentService.cancelPayment(
-                authResponse, merchantUid, order.getOrderNote() // 취소 사유
-                );
-
-        String cancelRst = (String) cancelResult.get("PCD_PAY_RST");
-        if (!"success".equalsIgnoreCase(cancelRst)) {
-          throw new RuntimeException("페이플 취소 요청 실패: " + cancelResult.get("PCD_PAY_MSG"));
-        }
+        PaymentCancelResponse response =
+            payplePaymentFacade.cancelPayment(
+                order.getUser().getId(), merchantUid, order.getOrderNote());
 
         // 주문 상태는 PayplePaymentService에서 이미 CANCELLED로 변경됨
         return AdminOrderCancelRequestDTO.builder()
-            .merchantUid(merchantUid)
+            .merchantUid(response.getMerchantUid())
             .action(action)
             .resultStatus(Order.OrderStatus.CANCELLED)
             .message("결제 취소가 승인되었습니다.")
-            .processedAt(java.time.LocalDateTime.now())
+            .processedAt(response.getCanceledAt())
             .build();
 
       } catch (Exception e) {


### PR DESCRIPTION
- 기존 데이터는 올바르게 SQL 쿼리로 수정
- AdminOrderService 클래스만 수정