### PR TITLE
hotfix: Payment Strategy 패턴 적용에 따른 환불 승인 처리 오류 핫픽스

### DIFF
--- a/groble-application/src/main/java/liaison/groble/application/admin/service/AdminOrderService.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/service/AdminOrderService.java
@@ -91,6 +91,7 @@ public class AdminOrderService {
         kakaoNotificationService.sendNotification(
             KakaoNotificationDTO.builder()
                 .type(KakaoNotificationType.APPROVE_CANCEL)
+                .phoneNumber(purchase.getPurchaserPhoneNumber())
                 .buyerName(purchase.getPurchaserName())
                 .contentTitle(purchase.getContent().getTitle())
                 .refundedAmount(order.getFinalPrice())

--- a/groble-application/src/main/java/liaison/groble/application/payment/service/PaypleApiClient.java
+++ b/groble-application/src/main/java/liaison/groble/application/payment/service/PaypleApiClient.java
@@ -157,7 +157,7 @@ public class PaypleApiClient {
       // 2. 환불 요청 생성
       PaypleRefundRequest refundRequest =
           PaypleRefundRequest.builder()
-              .url("https://testcpay.payple.kr/php/auth.php")
+              .url(paypleConfig.getCancelApiUrl())
               .cstId(paypleConfig.getCstId())
               .custKey(paypleConfig.getCustKey())
               .authKey(authResponse.getAuthKey())

--- a/groble-application/src/main/java/liaison/groble/application/payment/service/PaypleApiClient.java
+++ b/groble-application/src/main/java/liaison/groble/application/payment/service/PaypleApiClient.java
@@ -1,6 +1,5 @@
 package liaison.groble.application.payment.service;
 
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,15 +31,17 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PaypleApiClient {
   private static final String PAY_WORK_AUTH = "AUTH";
-  private static final String PAY_WORK_APPCARD = "APPCARD";
   private static final String RESULT_SUCCESS = "success";
-  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
   private final PaypleService paypleService;
   private final PaypleConfig paypleConfig;
 
   /**
    * 파트너 인증 요청
+   *
+   * <p>(1) 환불 요청에 사용
+   *
+   * <p>(2) 정산지급대행에 사용
    *
    * @param payWork 작업 구분
    * @return 인증 응답
@@ -137,7 +138,7 @@ public class PaypleApiClient {
   }
 
   /**
-   * 환불 요청
+   * 앱카드 환불 요청
    *
    * @param cancelInfo 취소 정보
    * @return 환불 결과
@@ -195,6 +196,23 @@ public class PaypleApiClient {
       throw new PaypleApiException("페이플 환불 요청 실패", e);
     }
   }
+
+  //    /**
+  //     * 계좌 인증 요청
+  //     *
+  //     * @param authResult 인증 결과
+  //     * @return 승인 결과 & 빌링키
+  //     */
+  //    @Retryable(value = PaypleApiException.class, maxAttempts = 2, backoff = @Backoff(delay =
+  // 500))
+  //    public PaypleAccountVerificationResult requestAccountVerification(PaymentSettlementInfo
+  // settlementInfo) {
+  //        log.info("페이플 계좌 인증 요청");
+  //
+  //        try {
+  //            PaypleAuthResponseDTO authResponse = requestAuth(PAY_WORK_AUTH);
+  //        }
+  //    }
 
   /** JSONObject에서 안전하게 문자열 추출 */
   private String getString(JSONObject json, String key) {

--- a/groble-application/src/main/java/liaison/groble/application/payment/service/PayplePaymentService.java
+++ b/groble-application/src/main/java/liaison/groble/application/payment/service/PayplePaymentService.java
@@ -660,7 +660,7 @@ public class PayplePaymentService {
             .format(java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
 
     return PaypleRefundRequest.builder()
-        .url("https://testcpay.payple.kr/php/auth.php") // 환불 URL 추가
+        .url(paypleConfig.getCancelApiUrl())
         .cstId(paypleConfig.getCstId())
         .custKey(paypleConfig.getCustKey())
         .authKey(authResponse.getAuthKey())

--- a/groble-application/src/main/java/liaison/groble/application/payment/strategy/GuestPaymentStrategy.java
+++ b/groble-application/src/main/java/liaison/groble/application/payment/strategy/GuestPaymentStrategy.java
@@ -54,9 +54,8 @@ public class GuestPaymentStrategy implements PaymentStrategy {
     return executionService.executePayment(
         authResult,
         () -> transactionService.saveAuthAndValidateForGuest(guestUserId, authResult),
-        (authInfo, approvalResult) ->
-            transactionService.completePaymentForGuest(authInfo, approvalResult),
-        completionResult -> eventPublisher.publishPaymentCompletedForGuest(completionResult));
+        transactionService::completePaymentForGuest,
+        eventPublisher::publishPaymentCompletedForGuest);
   }
 
   @Override

--- a/groble-application/src/main/java/liaison/groble/application/settlement/service/SettlementExecutionService.java
+++ b/groble-application/src/main/java/liaison/groble/application/settlement/service/SettlementExecutionService.java
@@ -1,0 +1,210 @@
+package liaison.groble.application.settlement.service;
+
+import org.springframework.stereotype.Service;
+
+import liaison.groble.application.payment.service.PaypleApiClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 정산 실행 서비스
+ *
+ * <p>정산 지급 대행의 공통 플로우를 담당하는 서비스입니다. 8단계의 정산 지급 대행 프로세스를 순차적으로 처리합니다: 1. 파트너 인증 요청 2. 인증 결과 검증 3. 계좌
+ * 인증 요청 4. 인증 결과, 빌링키 발급 검증 5. 빌링키로 이체 대기 요청 6. 요청 결과, 그룹키 발급 검증 7. 빌링키, 그룹키로 이체 실행 요청 8. 이체 실행 결과
+ * 반환
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SettlementExecutionService {
+  private final PaypleApiClient paypleApiClient;
+  //
+  //    /**
+  //     * 정산 지급 대행을 실행합니다.
+  //     *
+  //     * @param request 정산 요청 정보
+  //     * @return 정산 처리 결과
+  //     */
+  //    public SettlementExecutionResult executeSettlement(SettlementRequest request) {
+  //        log.info("정산 지급 대행 시작 - settlementId: {}", request.getSettlementId());
+  //
+  //        try {
+  //            // 1. 파트너 인증 요청
+  //            PartnerAuthRequest authRequest = buildPartnerAuthRequest(request);
+  //            PartnerAuthResult authResult = requestPartnerAuthentication(authRequest);
+  //            log.debug("파트너 인증 완료 - settlementId: {}", request.getSettlementId());
+  //
+  //            // 2. 인증 결과 검증
+  //            validateAuthenticationResult(authResult);
+  //            log.debug("파트너 인증 결과 검증 완료 - settlementId: {}", request.getSettlementId());
+  //
+  //            // 3. 계좌 인증 요청
+  //            AccountVerificationRequest accountRequest = buildAccountRequest(request,
+  // authResult);
+  //            AccountVerificationResult accountResult =
+  // requestAccountVerification(accountRequest);
+  //            log.debug("계좌 인증 완료 - settlementId: {}", request.getSettlementId());
+  //
+  //            // 4. 인증 결과 및 빌링키 발급 검증
+  //            String billingKey = validateAccountResult(accountResult);
+  //            log.debug("빌링키 발급 완료 - settlementId: {}, billingKey: {}", request.getSettlementId(),
+  // maskKey(billingKey));
+  //
+  //            // 5. 빌링키로 이체 대기 요청
+  //            TransferStandbyRequest standbyRequest = buildTransferStandbyRequest(request,
+  // billingKey);
+  //            TransferStandbyResult standbyResult = requestTransferStandby(standbyRequest);
+  //            log.debug("이체 대기 요청 완료 - settlementId: {}", request.getSettlementId());
+  //
+  //            // 6. 요청 결과 및 그룹키 발급 검증
+  //            String groupKey = validateStandbyResult(standbyResult);
+  //            log.debug("그룹키 발급 완료 - settlementId: {}, groupKey: {}", request.getSettlementId(),
+  // maskKey(groupKey));
+  //
+  //            // 7. 빌링키, 그룹키로 이체 실행 요청
+  //            TransferExecutionRequest executionRequest =
+  // buildTransferExecutionRequest(billingKey, groupKey, request);
+  //            TransferExecutionResult executionResult =
+  // requestTransferExecution(executionRequest);
+  //            log.debug("이체 실행 완료 - settlementId: {}", request.getSettlementId());
+  //
+  //            // 8. 이체 실행 결과 반환
+  //            SettlementExecutionResult finalResult = handleExecutionResult(executionResult,
+  // request);
+  //            log.info("정산 지급 대행 완료 - settlementId: {}, status: {}",
+  //                request.getSettlementId(), finalResult.getStatus());
+  //
+  //            return finalResult;
+  //
+  //        } catch (PartnerAuthException e) {
+  //            log.error("파트너 인증 실패 - settlementId: {}", request.getSettlementId(), e);
+  //            return handleSettlementFailure(request, e);
+  //        } catch (AccountVerificationException e) {
+  //            log.error("계좌 인증 실패 - settlementId: {}", request.getSettlementId(), e);
+  //            return handleSettlementFailure(request, e);
+  //        } catch (TransferException e) {
+  //            log.error("이체 처리 실패 - settlementId: {}", request.getSettlementId(), e);
+  //            return handleSettlementFailure(request, e);
+  //        } catch (Exception e) {
+  //            log.error("정산 지급 대행 중 예상치 못한 오류 - settlementId: {}", request.getSettlementId(), e);
+  //            return handleSettlementFailure(request, e);
+  //        }
+  //    }
+  //
+  //    private PartnerAuthRequest buildPartnerAuthRequest(SettlementRequest request) {
+  //        return PartnerAuthRequest.builder()
+  //            .partnerId(request.getPartnerId())
+  //            .partnerKey(request.getPartnerKey())
+  //            .settlementId(request.getSettlementId())
+  //            .build();
+  //    }
+  //
+  //    private PartnerAuthResult requestPartnerAuthentication(PartnerAuthRequest request) {
+  //        // Payple API를 통한 파트너 인증 요청
+  //        // 실제 구현 시 paypleApiClient.authenticatePartner() 호출
+  //        throw new UnsupportedOperationException("파트너 인증 API 구현 필요");
+  //    }
+  //
+  //    private void validateAuthenticationResult(PartnerAuthResult result) {
+  //        if (!result.isSuccess()) {
+  //            throw new PartnerAuthException("파트너 인증 실패: " + result.getErrorMessage());
+  //        }
+  //    }
+  //
+  //    private AccountVerificationRequest buildAccountRequest(SettlementRequest request,
+  // PartnerAuthResult authResult) {
+  //        return AccountVerificationRequest.builder()
+  //            .authToken(authResult.getAuthToken())
+  //            .bankCode(request.getBankCode())
+  //            .accountNumber(request.getAccountNumber())
+  //            .accountHolder(request.getAccountHolder())
+  //            .build();
+  //    }
+  //
+  //    private AccountVerificationResult requestAccountVerification(AccountVerificationRequest
+  // request) {
+  //        // Payple API를 통한 계좌 인증 요청
+  //        // 실제 구현 시 paypleApiClient.verifyAccount() 호출
+  //        throw new UnsupportedOperationException("계좌 인증 API 구현 필요");
+  //    }
+  //
+  //    private String validateAccountResult(AccountVerificationResult result) {
+  //        if (!result.isSuccess()) {
+  //            throw new AccountVerificationException("계좌 인증 실패: " + result.getErrorMessage());
+  //        }
+  //        if (result.getBillingKey() == null || result.getBillingKey().isEmpty()) {
+  //            throw new AccountVerificationException("빌링키 발급 실패");
+  //        }
+  //        return result.getBillingKey();
+  //    }
+  //
+  //    private TransferStandbyRequest buildTransferStandbyRequest(SettlementRequest request, String
+  // billingKey) {
+  //        return TransferStandbyRequest.builder()
+  //            .billingKey(billingKey)
+  //            .amount(request.getAmount())
+  //            .transferPurpose(request.getTransferPurpose())
+  //            .build();
+  //    }
+  //
+  //    private TransferStandbyResult requestTransferStandby(TransferStandbyRequest request) {
+  //        // Payple API를 통한 이체 대기 요청
+  //        // 실제 구현 시 paypleApiClient.requestTransferStandby() 호출
+  //        throw new UnsupportedOperationException("이체 대기 API 구현 필요");
+  //    }
+  //
+  //    private String validateStandbyResult(TransferStandbyResult result) {
+  //        if (!result.isSuccess()) {
+  //            throw new TransferException("이체 대기 요청 실패: " + result.getErrorMessage());
+  //        }
+  //        if (result.getGroupKey() == null || result.getGroupKey().isEmpty()) {
+  //            throw new TransferException("그룹키 발급 실패");
+  //        }
+  //        return result.getGroupKey();
+  //    }
+  //
+  //    private TransferExecutionRequest buildTransferExecutionRequest(String billingKey, String
+  // groupKey, SettlementRequest request) {
+  //        return TransferExecutionRequest.builder()
+  //            .billingKey(billingKey)
+  //            .groupKey(groupKey)
+  //            .settlementId(request.getSettlementId())
+  //            .amount(request.getAmount())
+  //            .build();
+  //    }
+  //
+  //    private TransferExecutionResult requestTransferExecution(TransferExecutionRequest request) {
+  //        // Payple API를 통한 이체 실행 요청
+  //        // 실제 구현 시 paypleApiClient.executeTransfer() 호출
+  //        throw new UnsupportedOperationException("이체 실행 API 구현 필요");
+  //    }
+  //
+  //    private SettlementExecutionResult handleExecutionResult(TransferExecutionResult result,
+  // SettlementRequest request) {
+  //        if (result.isSuccess()) {
+  //            return SettlementExecutionResult.success(
+  //                request.getSettlementId(),
+  //                result.getTransferId(),
+  //                result.getTransferAmount()
+  //            );
+  //        } else {
+  //            throw new TransferException("이체 실행 실패: " + result.getErrorMessage());
+  //        }
+  //    }
+  //
+  //    private SettlementExecutionResult handleSettlementFailure(SettlementRequest request,
+  // Exception e) {
+  //        return SettlementExecutionResult.failure(
+  //            request.getSettlementId(),
+  //            e.getMessage()
+  //        );
+  //    }
+  //
+  //    private String maskKey(String key) {
+  //        if (key == null || key.length() < 8) {
+  //            return "****";
+  //        }
+  //        return key.substring(0, 4) + "****" + key.substring(key.length() - 4);
+  //    }
+}

--- a/groble-domain/src/main/java/liaison/groble/domain/purchase/entity/Purchase.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/purchase/entity/Purchase.java
@@ -228,4 +228,13 @@ public class Purchase extends BaseTimeEntity {
     }
     return null;
   }
+
+  public String getPurchaserPhoneNumber() {
+    if (isMemberPurchase()) {
+      return this.user.getPhoneNumber();
+    } else if (isGuestPurchase()) {
+      return this.guestUser.getPhoneNumber();
+    }
+    return null;
+  }
 }

--- a/groble-infrastructure/groble-external/src/main/java/liaison/groble/external/adapter/payment/PaypleServiceV2.java
+++ b/groble-infrastructure/groble-external/src/main/java/liaison/groble/external/adapter/payment/PaypleServiceV2.java
@@ -175,10 +175,20 @@ public class PaypleServiceV2 implements PaypleService {
     requestBody.put("PCD_CST_ID", request.getCstId());
     requestBody.put("PCD_CUST_KEY", request.getCustKey());
     requestBody.put("PCD_AUTH_KEY", request.getAuthKey());
+    requestBody.put("PCD_REFUND_KEY", paypleConfig.getRefundKey());
+    requestBody.put("PCD_PAYCANCEL_FLAG", "Y");
     requestBody.put("PCD_PAY_OID", request.getPayOid());
+    requestBody.put(
+        "PCD_PAY_DATE", new java.text.SimpleDateFormat("yyyyMMdd").format(new java.util.Date()));
     requestBody.put("PCD_REFUND_TOTAL", request.getRefundTotal());
-    requestBody.put("PCD_REFUND_TAXFREE", request.getRefundTaxfree());
-    requestBody.put("PCD_REFUND_REASON", request.getRefundReason());
+
+    if (request.getRefundTaxfree() != null && !request.getRefundTaxfree().equals("0")) {
+      requestBody.put("PCD_REFUND_TAXTOTAL", request.getRefundTaxfree());
+    }
+
+    if (request.getRefundReason() != null) {
+      requestBody.put("PCD_REFUND_REASON", request.getRefundReason());
+    }
 
     log.debug("페이플 환불 요청 본문: {}", requestBody.toJSONString());
 

--- a/groble-infrastructure/groble-external/src/main/java/liaison/groble/external/adapter/payment/PaypleServiceV2.java
+++ b/groble-infrastructure/groble-external/src/main/java/liaison/groble/external/adapter/payment/PaypleServiceV2.java
@@ -144,7 +144,7 @@ public class PaypleServiceV2 implements PaypleService {
 
   private PaypleRefundRequest createRefundRequest(Map<String, String> params) {
     return PaypleRefundRequest.builder()
-        .url("https://testcpay.payple.kr/php/auth.php") // 테스트 환경 URL
+        .url(paypleConfig.getCancelApiUrl()) // 올바른 환불 API URL 사용
         .cstId(paypleConfig.getCstId())
         .custKey(paypleConfig.getCustKey())
         .authKey("test") // TODO: AuthKey 설정 필요

--- a/groble-infrastructure/groble-external/src/main/java/liaison/groble/external/config/PaypleConfig.java
+++ b/groble-infrastructure/groble-external/src/main/java/liaison/groble/external/config/PaypleConfig.java
@@ -26,6 +26,11 @@ public class PaypleConfig {
         : "https://cpay.payple.kr/js/v1/payment.js";
   }
 
+  // 정산지급대행 URL 설정
+  public String getSettlementUrl() {
+    return testMode ? "https://demohub.payple.kr/oauth/token" : "https://hub.payple.kr/oauth/token";
+  }
+
   public String getAuthApiUrl() {
     return testMode
         ? "https://democpay.payple.kr/php/auth.php"


### PR DESCRIPTION
### Issue
- 관리자의 서비스형 콘텐츠 환불 승인 서버 오류 발생
- 환불 승인 시 발송되는 결제 취소 알림톡 `phoneNumber` 미발송

### 원인
- 환불 승인 시 누락된 파라미터 존재 `PCD_REFUND_KEY`, `PCD_PAYCANCEL_FLAG`, `PCD_PAY_DATE` 3개 데이터 누락
- 알림톡 연동 과정에서 `phoneNumber` 누락 수정 (builder 패턴 이슈)

### 결과
- 환불 승인 요청 / 페이플 즉시 환불 처리 검증 완료