### PR TITLE
feat: 어드민 시스템 정산 관리/대시보드 기능 추가

### DIFF
--- a/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/dashboard/response/AdminDashboardOverviewResponse.java
+++ b/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/dashboard/response/AdminDashboardOverviewResponse.java
@@ -1,0 +1,46 @@
+package liaison.groble.api.model.admin.dashboard.response;
+
+import java.math.BigDecimal;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "관리자 페이지에서 대시보드 전체 요약 정보에 대한 응답 DTO")
+public class AdminDashboardOverviewResponse {
+
+  @Schema(description = "총 거래액 (금액)", example = "1500000000")
+  private BigDecimal totalTransactionAmount;
+
+  @Schema(description = "총 거래 건수", example = "1234")
+  private Long totalTransactionCount;
+
+  @Schema(description = "이번 달 거래액 (금액)", example = "50000000")
+  private BigDecimal monthlyTransactionAmount;
+
+  @Schema(description = "이번 달 거래 건수", example = "89")
+  private Long monthlyTransactionCount;
+
+  @Schema(description = "회원 수", example = "5678")
+  private Long userCount;
+
+  @Schema(description = "비회원 수", example = "234")
+  private Long guestUserCount;
+
+  @Schema(description = "전체 콘텐츠 수", example = "890")
+  private Long totalContentCount;
+
+  @Schema(description = "판매 중인 콘텐츠 수", example = "567")
+  private Long activeContentCount;
+
+  @Schema(description = "자료 유형 콘텐츠 개수", example = "234")
+  private Long documentTypeCount;
+
+  @Schema(description = "서비스 유형 콘텐츠 개수", example = "123")
+  private Long coachingTypeCount;
+
+  @Schema(description = "멤버십 유형 콘텐츠 개수", example = "45")
+  private Long membershipTypeCount;
+}

--- a/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/AdminSettlementDetailResponse.java
+++ b/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/AdminSettlementDetailResponse.java
@@ -1,0 +1,81 @@
+package liaison.groble.api.model.admin.settlement.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "관리자 페이지에서 정산 상세 정보에 대한 응답 DTO")
+public class AdminSettlementDetailResponse {
+  @Schema(
+      description = "정산 ID",
+      example = "1",
+      type = "number",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private Long settlementId;
+
+  // 정산 시작일 (년도 + 월) - Settlement class
+  @Schema(
+      description = "정산 시작일 (년도 + 월)",
+      example = "2023-01-01",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  private LocalDate settlementStartDate;
+
+  // 정산 종료일 (년도 + 월) - Settlement class
+  @Schema(
+      description = "정산 종료일 (년도 + 월)",
+      example = "2023-01-31",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  private LocalDate settlementEndDate;
+
+  // 정산(예정)일
+  @Schema(
+      description = "정산(예정)일",
+      example = "2023-02-01",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  private LocalDate scheduledSettlementDate;
+
+  // 정산(예정)금액
+  @Schema(
+      description = "정산(예정)금액 (원화 표기)",
+      example = "1000000",
+      type = "number",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private BigDecimal settlementAmount; // 정산 예정 금액 (원화 표기)
+
+  // PG사 수수료(1.7%)
+  @Schema(
+      description = "PG사 수수료 (1.7%)",
+      example = "17000",
+      type = "number",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private BigDecimal pgFee; // PG사 수수료 (1.7%)
+
+  // 그로블 수수료(1.5%)
+  @Schema(
+      description = "플랫폼 수수료 (1.5%)",
+      example = "15000",
+      type = "number",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private BigDecimal platformFee; // 플랫폼 수수료 (1.5%)
+
+  // VAT (10%)
+  @Schema(
+      description = "부가세 (10%)",
+      example = "1500",
+      type = "number",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private BigDecimal vatAmount;
+}

--- a/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/AdminSettlementsOverviewResponse.java
+++ b/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/AdminSettlementsOverviewResponse.java
@@ -1,0 +1,126 @@
+package liaison.groble.api.model.admin.settlement.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "관리자 페이지에서 정산 전체 정보에 대한 응답 DTO")
+public class AdminSettlementsOverviewResponse {
+
+  // 0. 정산 ID
+  @Schema(
+      description = "정산 ID",
+      example = "1",
+      type = "number",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private Long settlementId;
+
+  // 1. 정산(예정)일
+  @Schema(
+      description = "정산 예정일 (년도 + 월 + 일)",
+      example = "2023-02-10",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  private LocalDate scheduledSettlementDate;
+
+  // 2. 콘텐츠 종류
+  @Schema(
+      description = "콘텐츠 유형 (COACHING: 서비스, DOCUMENT: 자료)",
+      example = "DOCUMENT",
+      type = "string",
+      allowableValues = {"DOCUMENT", "COACHING"},
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String contentType;
+
+  // 3. 정산(예정)금액
+  @Schema(
+      description = "정산(예정)금액 (원화 표기)",
+      example = "1000000",
+      type = "number",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private BigDecimal settlementAmount;
+
+  // 4. 정산 상태
+  @Schema(
+      description =
+          "정산 상태 (PENDING: 정산 예정, PROCESSING: 정산 처리중, COMPLETED: 정산 완료, ON_HOLD: 정산 보류, CANCELLED: 정산 취소)",
+      example = "COMPLETED",
+      allowableValues = {"PENDING", "PROCESSING", "COMPLETED", "ON_HOLD", "CANCELLED"},
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String settlementStatus;
+
+  // 5. 메이커 인증 여부
+  @Schema(
+      description = "메이커 인증 상태 (isSellerInfo가 true라는 전제 하에 사용됩니다.)",
+      example = "VERIFIED",
+      type = "string",
+      allowableValues = {"PENDING", "IN_PROGRESS", "FAILED", "VERIFIED"},
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String verificationStatus;
+
+  // 6. 판매자 정보
+  @Schema(
+      description = "개인 메이커 / 사업자 여부",
+      example = "true",
+      type = "boolean",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private Boolean isBusinessSeller;
+
+  @Schema(
+      description = "사업자 유형 (개인사업자-간이과세자, 개인사업자-일반과세자, 법인사업자)",
+      example = "INDIVIDUAL_SIMPLE",
+      type = "string",
+      allowableValues = {"INDIVIDUAL_SIMPLE", "INDIVIDUAL_GENERAL", "CORPORATION"},
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  private String businessType;
+
+  @Schema(
+      description = "정산받을 예금주 이름 (계좌 소유자)",
+      example = "홍길동",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String bankAccountOwner;
+
+  @Schema(
+      description = "정산받을 은행명",
+      example = "국민은행",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String bankName;
+
+  @Schema(
+      description = "정산받을 계좌번호",
+      example = "123-456-78901234",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String bankAccountNumber;
+
+  @Schema(
+      description = "통장 사본 파일 URL",
+      example = "https://example.com/bankbook.jpg",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String copyOfBankbookUrl;
+
+  @Schema(
+      description = "사업자 등록증 파일 URL (isBusinessSeller가 true라는 전제 하에 사용됩니다.)",
+      example = "https://example.com/business_license.jpg",
+      type = "string",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  private String businessLicenseFileUrl;
+
+  @Schema(
+      description = "세금계산서 수취 이메일",
+      example = "example@example.com",
+      type = "string",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  private String taxInvoiceEmail;
+}

--- a/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/PerTransactionAdminSettlementOverviewResponse.java
+++ b/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/PerTransactionAdminSettlementOverviewResponse.java
@@ -1,0 +1,46 @@
+package liaison.groble.api.model.admin.settlement.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "[✅ 관리자 페이지 - 정산 관리] 정산 상세 정보 - 총 판매내역 내부 판매 정보 응답")
+public class PerTransactionAdminSettlementOverviewResponse {
+  @Schema(
+      description = "상품 제목",
+      example = "AI 툴 개발 가이드",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String contentTitle;
+
+  // 정산 금액
+  @Schema(
+      description = "실 정산 금액 (원화 표기)",
+      example = "9980000",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private BigDecimal settlementAmount;
+
+  @Schema(
+      description = "주문 상태 [PAID - 결제완료], [CANCEL_REQUEST - 결제취소], [CANCELLED - 환불완료]",
+      example = "CANCELLED",
+      type = "string",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  private String orderStatus;
+
+  // 판매일
+  @Schema(
+      description = "판매일 (YYYY-MM-DDTHH:mm:ss)",
+      example = "2023-01-15T10:30:00",
+      type = "date-time",
+      requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+  private LocalDateTime purchasedAt;
+}

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import liaison.groble.api.model.admin.dashboard.response.AdminDashboardOverviewResponse;
 import liaison.groble.api.server.admin.docs.AdminDashboardApiResponses;
-import liaison.groble.api.server.admin.docs.AdminSettlementSwaggerDocs;
+import liaison.groble.api.server.admin.docs.AdminDashboardSwaggerDocs;
 import liaison.groble.api.server.common.ApiPaths;
 import liaison.groble.api.server.common.BaseController;
 import liaison.groble.api.server.common.ResponseMessages;
@@ -29,8 +29,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RestController
 @RequestMapping(ApiPaths.Admin.DASHBOARD_BASE)
 @Tag(
-    name = AdminSettlementSwaggerDocs.TAG_NAME,
-    description = AdminSettlementSwaggerDocs.TAG_DESCRIPTION)
+    name = AdminDashboardSwaggerDocs.TAG_NAME,
+    description = AdminDashboardSwaggerDocs.TAG_DESCRIPTION)
 public class AdminDashboardController extends BaseController {
 
   // Service
@@ -50,8 +50,8 @@ public class AdminDashboardController extends BaseController {
 
   // 모든 전체 데이터 조회
   @Operation(
-      summary = AdminSettlementSwaggerDocs.ALL_USERS_SETTLEMENTS_SUMMARY,
-      description = AdminSettlementSwaggerDocs.ALL_USERS_SETTLEMENTS_DESCRIPTION)
+      summary = AdminDashboardSwaggerDocs.DASHBOARD_OVERVIEW_SUMMARY,
+      description = AdminDashboardSwaggerDocs.DASHBOARD_OVERVIEW_DESCRIPTION)
   @AdminDashboardApiResponses.GetAdminDashboardOverviewApiResponses
   @Logging(
       item = "AdminDashboard",

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
@@ -16,6 +16,7 @@ import liaison.groble.application.admin.dashboard.dto.AdminDashboardOverviewDTO;
 import liaison.groble.application.admin.dashboard.service.AdminDashboardService;
 import liaison.groble.common.annotation.Auth;
 import liaison.groble.common.annotation.Logging;
+import liaison.groble.common.annotation.RequireRole;
 import liaison.groble.common.model.Accessor;
 import liaison.groble.common.response.GrobleResponse;
 import liaison.groble.common.response.ResponseHelper;
@@ -57,6 +58,7 @@ public class AdminDashboardController extends BaseController {
       action = "getAdminDashboardOverview",
       includeParam = true,
       includeResult = true)
+  @RequireRole("ROLE_ADMIN")
   @GetMapping(ApiPaths.Admin.DASHBOARD_OVERVIEW)
   public ResponseEntity<GrobleResponse<AdminDashboardOverviewResponse>> getAdminDashboardOverview(
       @Auth Accessor accessor) {

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
@@ -1,0 +1,33 @@
+package liaison.groble.api.server.admin;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import liaison.groble.api.server.admin.docs.AdminSettlementSwaggerDocs;
+import liaison.groble.api.server.common.ApiPaths;
+import liaison.groble.api.server.common.BaseController;
+import liaison.groble.common.response.ResponseHelper;
+import liaison.groble.mapping.admin.AdminDashboardMapper;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Validated
+@RestController
+@RequestMapping(ApiPaths.Admin.DASHBOARD_BASE)
+@Tag(
+    name = AdminSettlementSwaggerDocs.TAG_NAME,
+    description = AdminSettlementSwaggerDocs.TAG_DESCRIPTION)
+public class AdminDashboardController extends BaseController {
+
+  // Service
+
+  // Mapper
+  private final AdminDashboardMapper adminDashboardMapper;
+
+  public AdminDashboardController(
+      ResponseHelper responseHelper, AdminDashboardMapper adminDashboardMapper) {
+    super(responseHelper);
+    this.adminDashboardMapper = adminDashboardMapper;
+  }
+}

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
@@ -30,4 +30,6 @@ public class AdminDashboardController extends BaseController {
     super(responseHelper);
     this.adminDashboardMapper = adminDashboardMapper;
   }
+
+  // 모든 유저의 정산 필요 항목 조회
 }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminDashboardController.java
@@ -1,15 +1,27 @@
 package liaison.groble.api.server.admin;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import liaison.groble.api.model.admin.dashboard.response.AdminDashboardOverviewResponse;
+import liaison.groble.api.server.admin.docs.AdminDashboardApiResponses;
 import liaison.groble.api.server.admin.docs.AdminSettlementSwaggerDocs;
 import liaison.groble.api.server.common.ApiPaths;
 import liaison.groble.api.server.common.BaseController;
+import liaison.groble.api.server.common.ResponseMessages;
+import liaison.groble.application.admin.dashboard.dto.AdminDashboardOverviewDTO;
+import liaison.groble.application.admin.dashboard.service.AdminDashboardService;
+import liaison.groble.common.annotation.Auth;
+import liaison.groble.common.annotation.Logging;
+import liaison.groble.common.model.Accessor;
+import liaison.groble.common.response.GrobleResponse;
 import liaison.groble.common.response.ResponseHelper;
 import liaison.groble.mapping.admin.AdminDashboardMapper;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Validated
@@ -24,12 +36,34 @@ public class AdminDashboardController extends BaseController {
 
   // Mapper
   private final AdminDashboardMapper adminDashboardMapper;
+  private final AdminDashboardService adminDashboardService;
 
   public AdminDashboardController(
-      ResponseHelper responseHelper, AdminDashboardMapper adminDashboardMapper) {
+      ResponseHelper responseHelper,
+      AdminDashboardMapper adminDashboardMapper,
+      AdminDashboardService adminDashboardService) {
     super(responseHelper);
     this.adminDashboardMapper = adminDashboardMapper;
+    this.adminDashboardService = adminDashboardService;
   }
 
-  // 모든 유저의 정산 필요 항목 조회
+  // 모든 전체 데이터 조회
+  @Operation(
+      summary = AdminSettlementSwaggerDocs.ALL_USERS_SETTLEMENTS_SUMMARY,
+      description = AdminSettlementSwaggerDocs.ALL_USERS_SETTLEMENTS_DESCRIPTION)
+  @AdminDashboardApiResponses.GetAdminDashboardOverviewApiResponses
+  @Logging(
+      item = "AdminDashboard",
+      action = "getAdminDashboardOverview",
+      includeParam = true,
+      includeResult = true)
+  @GetMapping(ApiPaths.Admin.DASHBOARD_OVERVIEW)
+  public ResponseEntity<GrobleResponse<AdminDashboardOverviewResponse>> getAdminDashboardOverview(
+      @Auth Accessor accessor) {
+    AdminDashboardOverviewDTO adminDashboardOverviewDTO =
+        adminDashboardService.getAdminDashboardOverview();
+    AdminDashboardOverviewResponse response =
+        adminDashboardMapper.toAdminDashboardOverviewResponse(adminDashboardOverviewDTO);
+    return success(response, ResponseMessages.Admin.DASHBOARD_OVERVIEW_RETRIEVED);
+  }
 }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import liaison.groble.api.model.admin.settlement.request.SettlementApprovalRequest;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementDetailResponse;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
+import liaison.groble.api.model.admin.settlement.response.PerTransactionAdminSettlementOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.SettlementApprovalResponse;
 import liaison.groble.api.server.admin.docs.AdminSettlementExampleResponses;
 import liaison.groble.api.server.admin.docs.AdminSettlementSwaggerDocs;
@@ -24,6 +25,7 @@ import liaison.groble.api.server.common.BaseController;
 import liaison.groble.api.server.common.ResponseMessages;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementDetailDTO;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDTO;
+import liaison.groble.application.admin.settlement.dto.PerTransactionAdminSettlementOverviewDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO.PaypleSettlementResultDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalRequestDTO;
@@ -129,6 +131,40 @@ public class AdminSettlementController extends BaseController {
         adminSettlementMapper.toAdminSettlementDetailResponse(adminSettlementDetailDTO);
 
     return success(response, ResponseMessages.Admin.SETTLEMENT_DETAIL_RETRIEVED);
+  }
+
+  @Operation(
+      summary = AdminSettlementSwaggerDocs.SETTLEMENT_DETAIL_SALES_SUMMARY,
+      description = AdminSettlementSwaggerDocs.SETTLEMENT_DETAIL_SALES_DESCRIPTION)
+  @AdminSettlementExampleResponses.AdminSettlementSalesListSuccess
+  @RequireRole("ROLE_ADMIN")
+  @Logging(
+      item = "AdminSettlement",
+      action = "getSalesList",
+      includeParam = true,
+      includeResult = true)
+  @GetMapping(ApiPaths.Admin.SALES_LIST)
+  public ResponseEntity<GrobleResponse<PageResponse<PerTransactionAdminSettlementOverviewResponse>>>
+      getSalesList(
+          @Auth Accessor accessor,
+          @Parameter(
+                  name = "settlementId",
+                  description = "숫자 형식",
+                  example = "265",
+                  schema = @Schema(type = "number"))
+              @PathVariable("settlementId")
+              Long settlementId,
+          @RequestParam(value = "page", defaultValue = "0") int page,
+          @RequestParam(value = "size", defaultValue = "20") int size,
+          @RequestParam(value = "sort", defaultValue = "createdAt") String sort) {
+    Pageable pageable = PageUtils.createPageable(page, size, sort);
+    PageResponse<PerTransactionAdminSettlementOverviewDTO> dtoPage =
+        adminSettlementService.getSalesList(settlementId, pageable);
+
+    PageResponse<PerTransactionAdminSettlementOverviewResponse> responsePage =
+        adminSettlementMapper.toPerTransactionAdminSettlementOverviewResponsePage(dtoPage);
+
+    return success(responsePage, ResponseMessages.Admin.SALES_LIST_RETRIEVED);
   }
 
   /**

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,6 +39,8 @@ import liaison.groble.common.utils.PageUtils;
 import liaison.groble.mapping.admin.AdminSettlementMapper;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 
@@ -111,7 +114,14 @@ public class AdminSettlementController extends BaseController {
       includeResult = true)
   @GetMapping(ApiPaths.Admin.SETTLEMENT_DETAIL)
   public ResponseEntity<GrobleResponse<AdminSettlementDetailResponse>> getSettlementsDetail(
-      @Auth Accessor accessor, @RequestParam Long settlementId) {
+      @Auth Accessor accessor,
+      @Parameter(
+              name = "settlementId",
+              description = "숫자 형식",
+              example = "265",
+              schema = @Schema(type = "number"))
+          @PathVariable("settlementId")
+          Long settlementId) {
     AdminSettlementDetailDTO adminSettlementDetailDTO =
         adminSettlementService.getSettlementDetail(settlementId);
 

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import liaison.groble.api.model.admin.settlement.request.SettlementApprovalRequest;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.SettlementApprovalResponse;
+import liaison.groble.api.server.admin.docs.AdminSettlementExampleResponses;
 import liaison.groble.api.server.admin.docs.AdminSettlementSwaggerDocs;
 import liaison.groble.api.server.common.ApiPaths;
 import liaison.groble.api.server.common.BaseController;
@@ -72,6 +73,7 @@ public class AdminSettlementController extends BaseController {
   @Operation(
       summary = AdminSettlementSwaggerDocs.ALL_USERS_SETTLEMENTS_SUMMARY,
       description = AdminSettlementSwaggerDocs.ALL_USERS_SETTLEMENTS_DESCRIPTION)
+  @AdminSettlementExampleResponses.AllUsersSettlementsPageSuccess
   @Logging(
       item = "AdminSettlement",
       action = "getAllUsersSettlements",

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
@@ -56,7 +56,7 @@ public class AdminSettlementController extends BaseController {
    * @param request 정산 승인 요청
    * @return 정산 승인 결과
    */
-  @PostMapping("/approve")
+  @PostMapping(ApiPaths.Admin.APPROVE_SETTLEMENTS)
   @AdminSettlementSwaggerDocs.ApproveSettlements
   public ResponseEntity<GrobleResponse<SettlementApprovalResponse>> approveSettlements(
       @Valid @RequestBody SettlementApprovalRequest request) {

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import liaison.groble.api.model.admin.settlement.request.SettlementApprovalRequest;
+import liaison.groble.api.model.admin.settlement.response.AdminSettlementDetailResponse;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.SettlementApprovalResponse;
 import liaison.groble.api.server.admin.docs.AdminSettlementExampleResponses;
@@ -20,6 +21,7 @@ import liaison.groble.api.server.admin.docs.AdminSettlementSwaggerDocs;
 import liaison.groble.api.server.common.ApiPaths;
 import liaison.groble.api.server.common.BaseController;
 import liaison.groble.api.server.common.ResponseMessages;
+import liaison.groble.application.admin.settlement.dto.AdminSettlementDetailDTO;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO.PaypleSettlementResultDTO;
@@ -27,6 +29,7 @@ import liaison.groble.application.admin.settlement.dto.SettlementApprovalRequest
 import liaison.groble.application.admin.settlement.service.AdminSettlementService;
 import liaison.groble.common.annotation.Auth;
 import liaison.groble.common.annotation.Logging;
+import liaison.groble.common.annotation.RequireRole;
 import liaison.groble.common.model.Accessor;
 import liaison.groble.common.response.GrobleResponse;
 import liaison.groble.common.response.PageResponse;
@@ -94,6 +97,28 @@ public class AdminSettlementController extends BaseController {
         adminSettlementMapper.toAdminSettlementsOverviewResponsePage(dtoPage);
 
     return success(responsePage, ResponseMessages.Admin.ALL_USERS_SETTLEMENTS_RETRIEVED);
+  }
+
+  @Operation(
+      summary = AdminSettlementSwaggerDocs.SETTLEMENT_DETAIL_SUMMARY,
+      description = AdminSettlementSwaggerDocs.SETTLEMENT_DETAIL_DESCRIPTION)
+  @AdminSettlementExampleResponses.AdminSettlementDetailSuccess
+  @RequireRole("ROLE_ADMIN")
+  @Logging(
+      item = "AdminSettlement",
+      action = "getSettlementsDetail",
+      includeParam = true,
+      includeResult = true)
+  @GetMapping(ApiPaths.Admin.SETTLEMENT_DETAIL)
+  public ResponseEntity<GrobleResponse<AdminSettlementDetailResponse>> getSettlementsDetail(
+      @Auth Accessor accessor, @RequestParam Long settlementId) {
+    AdminSettlementDetailDTO adminSettlementDetailDTO =
+        adminSettlementService.getSettlementDetail(settlementId);
+
+    AdminSettlementDetailResponse response =
+        adminSettlementMapper.toAdminSettlementDetailResponse(adminSettlementDetailDTO);
+
+    return success(response, ResponseMessages.Admin.SETTLEMENT_DETAIL_RETRIEVED);
   }
 
   /**

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardApiResponses.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardApiResponses.java
@@ -1,0 +1,80 @@
+package liaison.groble.api.server.admin.docs;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import liaison.groble.api.server.common.swagger.CommonSwaggerDocs;
+import liaison.groble.api.server.common.swagger.GenericResponseSchemas;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public final class AdminDashboardApiResponses {
+  private AdminDashboardApiResponses() {}
+
+  /** 관리자 대시보드 조회 API 응답 */
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = CommonSwaggerDocs.SUCCESS_200,
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema =
+                    @Schema(
+                        implementation =
+                            GenericResponseSchemas.ApiAdminDashboardOverviewResponse.class))),
+    @ApiResponse(
+        responseCode = "400",
+        description = CommonSwaggerDocs.BAD_REQUEST,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.BAD_REQUEST_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "403",
+        description = CommonSwaggerDocs.FORBIDDEN,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.FORBIDDEN_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "404",
+        description = CommonSwaggerDocs.NOT_FOUND,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.NOT_FOUND_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "409",
+        description = CommonSwaggerDocs.CONFLICT,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.CONFLICT_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "500",
+        description = CommonSwaggerDocs.SERVER_ERROR,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.SERVER_ERROR_EXAMPLE)))
+  })
+  public @interface GetAdminDashboardOverviewApiResponses {}
+}

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardApiResponses.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardApiResponses.java
@@ -9,6 +9,7 @@ import liaison.groble.api.server.common.swagger.CommonSwaggerDocs;
 import liaison.groble.api.server.common.swagger.GenericResponseSchemas;
 
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -29,16 +30,12 @@ public final class AdminDashboardApiResponses {
                 schema =
                     @Schema(
                         implementation =
-                            GenericResponseSchemas.ApiAdminDashboardOverviewResponse.class))),
-    @ApiResponse(
-        responseCode = "400",
-        description = CommonSwaggerDocs.BAD_REQUEST,
-        content =
-            @Content(
-                mediaType = "application/json",
+                            GenericResponseSchemas.ApiAdminDashboardOverviewResponse.class),
                 examples =
-                    @io.swagger.v3.oas.annotations.media.ExampleObject(
-                        value = CommonSwaggerDocs.BAD_REQUEST_EXAMPLE))),
+                    @ExampleObject(
+                        name = "성공 응답 예시",
+                        description = "관리자 대시보드 개요 조회 성공 시 응답 예시",
+                        value = AdminDashboardExamples.ADMIN_DASHBOARD_OVERVIEW_SUCCESS_EXAMPLE))),
     @ApiResponse(
         responseCode = "403",
         description = CommonSwaggerDocs.FORBIDDEN,
@@ -48,24 +45,6 @@ public final class AdminDashboardApiResponses {
                 examples =
                     @io.swagger.v3.oas.annotations.media.ExampleObject(
                         value = CommonSwaggerDocs.FORBIDDEN_EXAMPLE))),
-    @ApiResponse(
-        responseCode = "404",
-        description = CommonSwaggerDocs.NOT_FOUND,
-        content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                    @io.swagger.v3.oas.annotations.media.ExampleObject(
-                        value = CommonSwaggerDocs.NOT_FOUND_EXAMPLE))),
-    @ApiResponse(
-        responseCode = "409",
-        description = CommonSwaggerDocs.CONFLICT,
-        content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                    @io.swagger.v3.oas.annotations.media.ExampleObject(
-                        value = CommonSwaggerDocs.CONFLICT_EXAMPLE))),
     @ApiResponse(
         responseCode = "500",
         description = CommonSwaggerDocs.SERVER_ERROR,

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardExamples.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardExamples.java
@@ -1,0 +1,29 @@
+package liaison.groble.api.server.admin.docs;
+
+public final class AdminDashboardExamples {
+
+  private AdminDashboardExamples() {}
+
+  public static final String ADMIN_DASHBOARD_OVERVIEW_SUCCESS_EXAMPLE =
+      """
+      {
+        "status": "SUCCESS",
+        "code": 200,
+        "message": "관리자 대시보드 개요 조회가 성공적으로 처리되었습니다.",
+        "data": {
+          "totalTransactionAmount": 1500000000,
+          "totalTransactionCount": 1234,
+          "monthlyTransactionAmount": 50000000,
+          "monthlyTransactionCount": 89,
+          "userCount": 5678,
+          "guestUserCount": 234,
+          "totalContentCount": 890,
+          "activeContentCount": 567,
+          "documentTypeCount": 234,
+          "coachingTypeCount": 123,
+          "membershipTypeCount": 45
+        },
+        "timestamp": "2025-08-31T07:06:06.312Z"
+      }
+      """;
+}

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardSwaggerDocs.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardSwaggerDocs.java
@@ -1,0 +1,11 @@
+package liaison.groble.api.server.admin.docs;
+
+import liaison.groble.api.server.common.swagger.SwaggerTags;
+
+public final class AdminDashboardSwaggerDocs {
+  private AdminDashboardSwaggerDocs() {}
+
+  // === 공통 태그 ===
+  public static final String TAG_NAME = SwaggerTags.Admin.DASHBOARD;
+  public static final String TAG_DESCRIPTION = SwaggerTags.Admin.DASHBOARD_DESC;
+}

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardSwaggerDocs.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminDashboardSwaggerDocs.java
@@ -8,4 +8,14 @@ public final class AdminDashboardSwaggerDocs {
   // === 공통 태그 ===
   public static final String TAG_NAME = SwaggerTags.Admin.DASHBOARD;
   public static final String TAG_DESCRIPTION = SwaggerTags.Admin.DASHBOARD_DESC;
+
+  // === 대시보드 개요 조회 API ===
+  public static final String DASHBOARD_OVERVIEW_SUMMARY = "[✅ 대시보드 개요 조회] 관리자가 대시보드 개요 정보를 조회합니다.";
+  public static final String DASHBOARD_OVERVIEW_DESCRIPTION =
+      """
+                      관리자가 대시보드 개요 정보를 조회합니다.
+
+                      **응답 데이터:**
+                      - 주요 통계 정보 포함 (총 사용자 수, 총 콘텐츠 수, 총 매출 등)
+                      """;
 }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementApiResponses.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementApiResponses.java
@@ -1,0 +1,3 @@
+package liaison.groble.api.server.admin.docs;
+
+public class AdminSettlementApiResponses {}

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExampleResponses.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExampleResponses.java
@@ -74,4 +74,53 @@ public final class AdminSettlementExampleResponses {
                         value = CommonSwaggerDocs.SERVER_ERROR_EXAMPLE)))
   })
   public @interface AllUsersSettlementsPageSuccess {}
+
+  /** 관리자 특정 정산 항목 상세 내역 조회 성공 응답 */
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = CommonSwaggerDocs.SUCCESS_200,
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema =
+                    @Schema(
+                        implementation =
+                            GenericResponseSchemas.ApiAdminSettlementDetailResponse.class),
+                examples =
+                    @ExampleObject(
+                        name = "성공 응답 예시",
+                        description = "정산 상세 조회 성공 시 응답 예시",
+                        value = AdminSettlementExamples.ADMIN_SETTLEMENT_DETAIL_SUCCESS_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "403",
+        description = CommonSwaggerDocs.FORBIDDEN,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.FORBIDDEN_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "404",
+        description = CommonSwaggerDocs.NOT_FOUND,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.NOT_FOUND_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "500",
+        description = CommonSwaggerDocs.SERVER_ERROR,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.SERVER_ERROR_EXAMPLE)))
+  })
+  public @interface AdminSettlementDetailSuccess {}
 }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExampleResponses.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExampleResponses.java
@@ -1,0 +1,77 @@
+package liaison.groble.api.server.admin.docs;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import liaison.groble.api.server.common.swagger.CommonSwaggerDocs;
+import liaison.groble.api.server.common.swagger.GenericResponseSchemas;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public final class AdminSettlementExampleResponses {
+  private AdminSettlementExampleResponses() {}
+
+  /** 관리자 전체 사용자 정산 내역 조회 성공 응답 */
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = CommonSwaggerDocs.SUCCESS_200,
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema =
+                    @Schema(
+                        implementation =
+                            GenericResponseSchemas.ApiAllUsersSettlementsResponse.class),
+                examples =
+                    @ExampleObject(
+                        name = "성공 응답 예시",
+                        description = "전체 사용자 정산 내역 조회 성공 시 응답 예시",
+                        value = AdminSettlementExamples.ALL_USERS_SETTLEMENTS_SUCCESS_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "403",
+        description = CommonSwaggerDocs.FORBIDDEN,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.FORBIDDEN_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "404",
+        description = CommonSwaggerDocs.NOT_FOUND,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.NOT_FOUND_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "409",
+        description = CommonSwaggerDocs.CONFLICT,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.CONFLICT_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "500",
+        description = CommonSwaggerDocs.SERVER_ERROR,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.SERVER_ERROR_EXAMPLE)))
+  })
+  public @interface AllUsersSettlementsPageSuccess {}
+}

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExampleResponses.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExampleResponses.java
@@ -123,4 +123,6 @@ public final class AdminSettlementExampleResponses {
                         value = CommonSwaggerDocs.SERVER_ERROR_EXAMPLE)))
   })
   public @interface AdminSettlementDetailSuccess {}
+
+  public @interface AdminSettlementSalesListSuccess {}
 }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExamples.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExamples.java
@@ -1,0 +1,76 @@
+package liaison.groble.api.server.admin.docs;
+
+public final class AdminSettlementExamples {
+
+  private AdminSettlementExamples() {}
+
+  public static final String ALL_USERS_SETTLEMENTS_SUCCESS_EXAMPLE =
+      """
+      {
+        "success": true,
+        "code": "SUCCESS",
+        "message": "전체 사용자 정산 목록 조회가 성공적으로 처리되었습니다.",
+        "data": {
+          "items": [
+            {
+              "settlementId": 123,
+              "scheduledSettlementDate": "2025-01-15",
+              "contentType": "COACHING",
+              "settlementAmount": 180000.00,
+              "settlementStatus": "PENDING",
+              "verificationStatus": "VERIFIED",
+              "isBusinessSeller": true,
+              "businessType": "INDIVIDUAL_GENERAL",
+              "bankAccountOwner": "김그로블",
+              "bankName": "국민은행",
+              "bankAccountNumber": "123456-12-123456",
+              "copyOfBankbookUrl": "https://example.com/bankbook/copy1.jpg",
+              "businessLicenseFileUrl": "https://example.com/license/business1.pdf",
+              "taxInvoiceEmail": "maker@example.com"
+            },
+            {
+              "settlementId": 124,
+              "scheduledSettlementDate": "2025-01-15",
+              "contentType": "DOCUMENT",
+              "settlementAmount": 95000.00,
+              "settlementStatus": "PENDING",
+              "verificationStatus": "IN_PROGRESS",
+              "isBusinessSeller": false,
+              "businessType": null,
+              "bankAccountOwner": "이메이커",
+              "bankName": "신한은행",
+              "bankAccountNumber": "110-123-123456",
+              "copyOfBankbookUrl": "https://example.com/bankbook/copy2.jpg",
+              "businessLicenseFileUrl": null,
+              "taxInvoiceEmail": "personal.maker@example.com"
+            },
+            {
+              "settlementId": 125,
+              "scheduledSettlementDate": "2025-01-10",
+              "contentType": "COACHING",
+              "settlementAmount": 250000.00,
+              "settlementStatus": "COMPLETED",
+              "verificationStatus": "VERIFIED",
+              "isBusinessSeller": true,
+              "businessType": "CORPORATION",
+              "bankAccountOwner": "(주)그로블코칭",
+              "bankName": "하나은행",
+              "bankAccountNumber": "123-456789-12345",
+              "copyOfBankbookUrl": "https://example.com/bankbook/copy3.jpg",
+              "businessLicenseFileUrl": "https://example.com/license/business3.pdf",
+              "taxInvoiceEmail": "tax@groblecoaching.com"
+            }
+          ],
+          "pageInfo": {
+            "currentPage": 0,
+            "totalPages": 5,
+            "pageSize": 20,
+            "totalElements": 87,
+            "first": true,
+            "last": false,
+            "empty": false
+          }
+        }
+      }
+      """;
+}

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExamples.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExamples.java
@@ -73,4 +73,23 @@ public final class AdminSettlementExamples {
         }
       }
       """;
+
+  public static final String ADMIN_SETTLEMENT_DETAIL_SUCCESS_EXAMPLE =
+      """
+      {
+        "success": true,
+        "code": "SUCCESS",
+        "message": "정산 상세 정보 조회가 성공적으로 처리되었습니다.",
+        "data": {
+          "settlementId": 123,
+          "settlementStartDate": "2025-01-01",
+          "settlementEndDate": "2025-01-31",
+          "scheduledSettlementDate": "2025-02-15",
+          "settlementAmount": 180000.00,
+          "pgFee": 3060.00,
+          "platformFee": 2700.00,
+          "vatAmount": 270.00
+        }
+      }
+      """;
 }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementSwaggerDocs.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementSwaggerDocs.java
@@ -31,6 +31,21 @@ public final class AdminSettlementSwaggerDocs {
                     - 페이징 정보 포함 (총 페이지 수, 현재 페이지 등)
                     """;
 
+  // === 정산 상세 내역 조회 API ===
+  public static final String SETTLEMENT_DETAIL_SUMMARY =
+      "[✅ 정산 상세 내역 조회] 관리자가 특정 정산 항목의 상세 내역을 조회합니다.";
+  public static final String SETTLEMENT_DETAIL_DESCRIPTION =
+      """
+                    관리자가 특정 정산 항목의 상세 내역을 조회합니다.
+
+                    **요청 파라미터:**
+                    - settlementId: 조회할 정산 항목의 고유 ID
+
+                    **응답 데이터:**
+                    - 정산 항목의 상세 정보 포함
+                    - 관련된 결제 및 환불 내역 포함
+                    """;
+
   @Operation(
       summary = "정산 승인 처리",
       description =

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementSwaggerDocs.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementSwaggerDocs.java
@@ -45,6 +45,20 @@ public final class AdminSettlementSwaggerDocs {
                     - 정산 항목의 상세 정보 포함
                     - 관련된 결제 및 환불 내역 포함
                     """;
+  // === 정산 상세 총 판매 내역 조회 API ===
+  public static final String SETTLEMENT_DETAIL_SALES_SUMMARY =
+      "[✅ 정산 상세 총 판매 내역 조회] 관리자가 특정 정산 항목의 총 판매 내역을 조회합니다.";
+  public static final String SETTLEMENT_DETAIL_SALES_DESCRIPTION =
+      """
+                      관리자가 특정 정산 항목의 총 판매 내역을 조회합니다.
+
+                      **요청 파라미터:**
+                      - settlementId: 조회할 정산 항목의 고유 ID
+
+                      **응답 데이터:**
+                      - 해당 정산 항목에 포함된 모든 판매 내역 리스트
+                      - 각 판매 내역에 대한 상세 정보 포함
+                      """;
 
   @Operation(
       summary = "정산 승인 처리",

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementSwaggerDocs.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementSwaggerDocs.java
@@ -19,6 +19,18 @@ public final class AdminSettlementSwaggerDocs {
   public static final String TAG_NAME = SwaggerTags.Admin.SETTLEMENT;
   public static final String TAG_DESCRIPTION = SwaggerTags.Admin.SETTLEMENT_DESC;
 
+  // === 모든 사용자의 정산 내역 조회 API ===
+  public static final String ALL_USERS_SETTLEMENTS_SUMMARY =
+      "[✅ 전체 사용자 정산 내역 조회] 관리자가 모든 사용자의 정산 내역을 페이징 처리하여 조회합니다.";
+  public static final String ALL_USERS_SETTLEMENTS_DESCRIPTION =
+      """
+                    관리자가 모든 사용자의 정산 내역을 페이징 처리하여 조회합니다.
+
+                    **응답 데이터:**
+                    - 각 정산 항목에 대한 상세 정보 포함
+                    - 페이징 정보 포함 (총 페이지 수, 현재 페이지 등)
+                    """;
+
   @Operation(
       summary = "정산 승인 처리",
       description =

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
@@ -15,6 +15,8 @@ public final class ApiPaths {
 
     public static final String APPROVE_SETTLEMENTS = "/approve";
 
+    public static final String ALL_USERS_SETTLEMENTS = "/all-users";
+
     private Admin() {}
   }
 

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
@@ -10,6 +10,7 @@ public final class ApiPaths {
     public static final String BASE = API_V1 + "/admin";
 
     public static final String DASHBOARD_BASE = BASE + "/dashboard";
+    public static final String DASHBOARD_OVERVIEW = "/overview";
 
     public static final String SETTLEMENT_BASE = BASE + "/settlements";
 

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
@@ -6,19 +6,21 @@ public final class ApiPaths {
 
   public static final String API_V1 = "/api/v1";
 
+  public static final class Admin {
+    public static final String BASE = API_V1 + "/admin";
+    public static final String SETTLEMENT_BASE = BASE + "/settlements";
+
+    public static final String APPROVE_SETTLEMENTS = "/approve";
+
+    private Admin() {}
+  }
+
   public static final class Guest {
     public static final String BASE_AUTH = API_V1 + "/guest/auth";
 
     public static final String PHONE_CODE_REQUEST = "/code-request";
     public static final String PHONE_CODE_VERIFY = "/verify-request";
     public static final String UPDATE_GUEST_USER_INFO = "/update-info";
-  }
-
-  public static final class Admin {
-    public static final String BASE = API_V1 + "/admin";
-    public static final String SETTLEMENT_BASE = BASE + "/settlements";
-
-    private Admin() {}
   }
 
   public static final class Payment {

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
@@ -8,6 +8,9 @@ public final class ApiPaths {
 
   public static final class Admin {
     public static final String BASE = API_V1 + "/admin";
+
+    public static final String DASHBOARD_BASE = BASE + "/dashboard";
+
     public static final String SETTLEMENT_BASE = BASE + "/settlements";
 
     public static final String APPROVE_SETTLEMENTS = "/approve";

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
@@ -17,6 +17,8 @@ public final class ApiPaths {
     public static final String APPROVE_SETTLEMENTS = "/approve";
 
     public static final String ALL_USERS_SETTLEMENTS = "/all-users";
+    public static final String SETTLEMENT_DETAIL = "/{settlementId}";
+    public static final String SALES_LIST = "/sales/{settlementId}";
 
     private Admin() {}
   }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
@@ -11,6 +11,7 @@ public final class ResponseMessages {
   }
 
   public static final class Admin {
+    public static final String DASHBOARD_OVERVIEW_RETRIEVED = "관리자 대시보드 개요 조회에 성공하였습니다.";
     public static final String SETTLEMENT_APPROVAL_SUCCESS = "정산 승인 요청이 성공적으로 처리되었습니다.";
 
     public static final String ALL_USERS_SETTLEMENTS_RETRIEVED = "전체 사용자 정산 내역 조회에 성공하였습니다.";

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
@@ -12,6 +12,8 @@ public final class ResponseMessages {
 
   public static final class Admin {
     public static final String SETTLEMENT_APPROVAL_SUCCESS = "정산 승인 요청이 성공적으로 처리되었습니다.";
+
+    public static final String ALL_USERS_SETTLEMENTS_RETRIEVED = "전체 사용자 정산 내역 조회에 성공하였습니다.";
   }
 
   public static final class Payment {

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
@@ -15,6 +15,7 @@ public final class ResponseMessages {
     public static final String SETTLEMENT_APPROVAL_SUCCESS = "정산 승인 요청이 성공적으로 처리되었습니다.";
 
     public static final String ALL_USERS_SETTLEMENTS_RETRIEVED = "전체 사용자 정산 내역 조회에 성공하였습니다.";
+    public static final String SETTLEMENT_DETAIL_RETRIEVED = "사용자 정산 상세 내역 조회에 성공하였습니다.";
   }
 
   public static final class Payment {

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
@@ -16,6 +16,7 @@ public final class ResponseMessages {
 
     public static final String ALL_USERS_SETTLEMENTS_RETRIEVED = "전체 사용자 정산 내역 조회에 성공하였습니다.";
     public static final String SETTLEMENT_DETAIL_RETRIEVED = "사용자 정산 상세 내역 조회에 성공하였습니다.";
+    public static final String SALES_LIST_RETRIEVED = "정산별 판매 내역 조회에 성공하였습니다.";
   }
 
   public static final class Payment {

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/GenericResponseSchemas.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/GenericResponseSchemas.java
@@ -1,6 +1,7 @@
 package liaison.groble.api.server.common.swagger;
 
 import liaison.groble.api.model.admin.dashboard.response.AdminDashboardOverviewResponse;
+import liaison.groble.api.model.admin.settlement.response.AdminSettlementDetailResponse;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.guest.response.GuestAuthCodeResponse;
 import liaison.groble.api.model.guest.response.UpdateGuestUserInfoResponse;
@@ -327,6 +328,7 @@ public final class GenericResponseSchemas {
     public String timestamp;
   }
 
+  @Schema(description = CommonSwaggerDocs.GROBLE_RESPONSE_DESC + " - 관리자 대시보드 개요 응답")
   public static class ApiAdminDashboardOverviewResponse {
 
     @Schema(description = "응답 상태", example = CommonSwaggerDocs.STATUS_SUCCESS)
@@ -361,6 +363,25 @@ public final class GenericResponseSchemas {
 
     @Schema(description = "전체 사용자 정산 내역 데이터 (페이징)")
     public PageResponse<AdminSettlementsOverviewResponse> data;
+
+    @Schema(description = "응답 시간", example = "2025-08-31T07:06:06.312Z")
+    public String timestamp;
+  }
+
+  @Schema(description = CommonSwaggerDocs.GROBLE_RESPONSE_DESC + " - 관리자 정산 상세 조회 응답")
+  public static class ApiAdminSettlementDetailResponse {
+
+    @Schema(description = "응답 상태", example = CommonSwaggerDocs.STATUS_SUCCESS)
+    public String status;
+
+    @Schema(description = "HTTP 상태 코드", example = "200")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = ResponseMessages.Admin.SETTLEMENT_DETAIL_RETRIEVED)
+    public String message;
+
+    @Schema(description = "정산 상세 정보 데이터")
+    public AdminSettlementDetailResponse data;
 
     @Schema(description = "응답 시간", example = "2025-08-31T07:06:06.312Z")
     public String timestamp;

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/GenericResponseSchemas.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/GenericResponseSchemas.java
@@ -1,5 +1,6 @@
 package liaison.groble.api.server.common.swagger;
 
+import liaison.groble.api.model.admin.dashboard.response.AdminDashboardOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.guest.response.GuestAuthCodeResponse;
 import liaison.groble.api.model.guest.response.UpdateGuestUserInfoResponse;
@@ -321,6 +322,24 @@ public final class GenericResponseSchemas {
 
     @Schema(description = "비회원 사용자 정보 업데이트 및 정식 토큰 발급 응답")
     public UpdateGuestUserInfoResponse data;
+
+    @Schema(description = "응답 시간", example = "2025-08-31T07:06:06.312Z")
+    public String timestamp;
+  }
+
+  public static class ApiAdminDashboardOverviewResponse {
+
+    @Schema(description = "응답 상태", example = CommonSwaggerDocs.STATUS_SUCCESS)
+    public String status;
+
+    @Schema(description = "HTTP 상태 코드", example = "200")
+    public int code;
+
+    @Schema(description = "응답 메시지", example = ResponseMessages.Admin.DASHBOARD_OVERVIEW_RETRIEVED)
+    public String message;
+
+    @Schema(description = "관리자 대시보드 개요 데이터")
+    public AdminDashboardOverviewResponse data;
 
     @Schema(description = "응답 시간", example = "2025-08-31T07:06:06.312Z")
     public String timestamp;

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/GenericResponseSchemas.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/GenericResponseSchemas.java
@@ -1,5 +1,6 @@
 package liaison.groble.api.server.common.swagger;
 
+import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.guest.response.GuestAuthCodeResponse;
 import liaison.groble.api.model.guest.response.UpdateGuestUserInfoResponse;
 import liaison.groble.api.model.guest.response.VerifyAuthCodeResponse;
@@ -320,6 +321,27 @@ public final class GenericResponseSchemas {
 
     @Schema(description = "비회원 사용자 정보 업데이트 및 정식 토큰 발급 응답")
     public UpdateGuestUserInfoResponse data;
+
+    @Schema(description = "응답 시간", example = "2025-08-31T07:06:06.312Z")
+    public String timestamp;
+  }
+
+  @Schema(description = CommonSwaggerDocs.GROBLE_RESPONSE_DESC + " - 관리자 전체 사용자 정산 내역 조회 응답")
+  public static class ApiAllUsersSettlementsResponse {
+
+    @Schema(description = "응답 상태", example = CommonSwaggerDocs.STATUS_SUCCESS)
+    public String status;
+
+    @Schema(description = "HTTP 상태 코드", example = "200")
+    public int code;
+
+    @Schema(
+        description = "응답 메시지",
+        example = ResponseMessages.Admin.ALL_USERS_SETTLEMENTS_RETRIEVED)
+    public String message;
+
+    @Schema(description = "전체 사용자 정산 내역 데이터")
+    public AdminSettlementsOverviewResponse data;
 
     @Schema(description = "응답 시간", example = "2025-08-31T07:06:06.312Z")
     public String timestamp;

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/GenericResponseSchemas.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/GenericResponseSchemas.java
@@ -340,8 +340,8 @@ public final class GenericResponseSchemas {
         example = ResponseMessages.Admin.ALL_USERS_SETTLEMENTS_RETRIEVED)
     public String message;
 
-    @Schema(description = "전체 사용자 정산 내역 데이터")
-    public AdminSettlementsOverviewResponse data;
+    @Schema(description = "전체 사용자 정산 내역 데이터 (페이징)")
+    public PageResponse<AdminSettlementsOverviewResponse> data;
 
     @Schema(description = "응답 시간", example = "2025-08-31T07:06:06.312Z")
     public String timestamp;

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/SwaggerTags.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/SwaggerTags.java
@@ -60,13 +60,18 @@ public final class SwaggerTags {
   }
 
   public static final class Admin {
-    public static final String USER = "[✅ 관리자] 사용자 관리 API";
-    public static final String USER_DESC = "관리자의 사용자 관리 기능을 제공합니다.";
-    public static final String CONTENT = "[✅ 관리자] 콘텐츠 관리 API";
-    public static final String CONTENT_DESC = "관리자의 콘텐츠 관리 및 모니터링 기능을 제공합니다.";
     public static final String AUTH = "[✅ 관리자 인증/인가] 관리자 로그인 및 로그아웃";
     public static final String AUTH_DESC = "관리자의 로그인 및 로그아웃 기능을 제공합니다.";
-    public static final String SETTLEMENT = "[✅ 정산 관리] 정산 관리 API";
+
+    public static final String DASHBOARD = "[✅ 관리자 대시보드] 관리자 대시보드 API";
+    public static final String DASHBOARD_DESC = "관리자 대시보드에 필요한 통계,요약,알림 정보를 제공합니다.";
+
+    public static final String USER = "[✅ 관리자 사용자 관리] 사용자 관리 API";
+    public static final String USER_DESC = "관리자의 사용자 관리 기능을 제공합니다.";
+    public static final String CONTENT = "[✅ 관리자 콘텐츠 관리] 콘텐츠 관리 API";
+    public static final String CONTENT_DESC = "관리자의 콘텐츠 관리 및 모니터링 기능을 제공합니다.";
+
+    public static final String SETTLEMENT = "[✅ 관리자 정산 관리] 정산 관리 API";
     public static final String SETTLEMENT_DESC = "정산 내역 조회 및 정산 완료 기능을 제공합니다.";
 
     private Admin() {}

--- a/groble-application/src/main/java/liaison/groble/application/admin/dashboard/dto/AdminDashboardOverviewDTO.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/dashboard/dto/AdminDashboardOverviewDTO.java
@@ -1,0 +1,22 @@
+package liaison.groble.application.admin.dashboard.dto;
+
+import java.math.BigDecimal;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminDashboardOverviewDTO {
+  private BigDecimal totalTransactionAmount;
+  private Long totalTransactionCount;
+  private BigDecimal monthlyTransactionAmount;
+  private Long monthlyTransactionCount;
+  private Long userCount;
+  private Long guestUserCount;
+  private Long totalContentCount;
+  private Long activeContentCount;
+  private Long documentTypeCount;
+  private Long coachingTypeCount;
+  private Long membershipTypeCount;
+}

--- a/groble-application/src/main/java/liaison/groble/application/admin/dashboard/service/AdminDashboardService.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/dashboard/service/AdminDashboardService.java
@@ -1,0 +1,77 @@
+package liaison.groble.application.admin.dashboard.service;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import liaison.groble.application.admin.dashboard.dto.AdminDashboardOverviewDTO;
+import liaison.groble.application.purchase.service.PurchaseReader;
+import liaison.groble.domain.content.enums.ContentStatus;
+import liaison.groble.domain.content.repository.ContentRepository;
+import liaison.groble.domain.dashboard.dto.FlatDashboardOverviewDTO;
+import liaison.groble.domain.guest.repository.GuestUserRepository;
+import liaison.groble.domain.user.enums.UserStatus;
+import liaison.groble.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 관리자 대시보드 서비스
+ *
+ * <p>관리자가 대시보드를 조회하는 비즈니스 로직을 담당합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminDashboardService {
+
+  // Repository
+  private final UserRepository userRepository;
+  private final ContentRepository contentRepository;
+  private final GuestUserRepository guestUserRepository;
+
+  // Reader
+  private final PurchaseReader purchaseReader;
+
+  @Transactional(readOnly = true)
+  public AdminDashboardOverviewDTO getAdminDashboardOverview() {
+    // 거래 통계 조회
+    FlatDashboardOverviewDTO transactionStats = purchaseReader.getAdminDashboardOverviewStats();
+
+    // 사용자 통계 조회
+    long userCount = userRepository.countByStatus(UserStatus.ACTIVE);
+    long guestUserCount = guestUserRepository.count();
+
+    // 콘텐츠 통계 조회
+    List<ContentStatus> allStatuses =
+        Arrays.asList(ContentStatus.DRAFT, ContentStatus.ACTIVE, ContentStatus.DISCONTINUED);
+    List<ContentStatus> activeStatuses = Arrays.asList(ContentStatus.DRAFT, ContentStatus.ACTIVE);
+
+    long totalContentCount = contentRepository.countByStatusIn(allStatuses);
+    long activeContentCount = contentRepository.countByStatusIn(activeStatuses);
+    long documentTypeCount =
+        contentRepository.countByContentTypeAndStatusIn("DOCUMENT", activeStatuses);
+    long coachingTypeCount =
+        contentRepository.countByContentTypeAndStatusIn("COACHING", activeStatuses);
+    long membershipTypeCount = 0L;
+    //        contentRepository.countByContentTypeAndStatusIn("MEMBERSHIP", activeStatuses);
+
+    return AdminDashboardOverviewDTO.builder()
+        .totalTransactionAmount(transactionStats.getTotalRevenue())
+        .totalTransactionCount(transactionStats.getTotalSalesCount())
+        .monthlyTransactionAmount(transactionStats.getCurrentMonthRevenue())
+        .monthlyTransactionCount(transactionStats.getCurrentMonthSalesCount())
+        .userCount(userCount)
+        .guestUserCount(guestUserCount)
+        .totalContentCount(totalContentCount)
+        .activeContentCount(activeContentCount)
+        .documentTypeCount(documentTypeCount)
+        .coachingTypeCount(coachingTypeCount)
+        .membershipTypeCount(membershipTypeCount)
+        .build();
+  }
+}

--- a/groble-application/src/main/java/liaison/groble/application/admin/dashboard/service/AdminDashboardService.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/dashboard/service/AdminDashboardService.java
@@ -54,9 +54,9 @@ public class AdminDashboardService {
     long totalContentCount = contentRepository.countByStatusIn(allStatuses);
     long activeContentCount = contentRepository.countByStatusIn(activeStatuses);
     long documentTypeCount =
-        contentRepository.countByContentTypeAndStatusIn("DOCUMENT", activeStatuses);
+        contentRepository.countByContentTypeAndStatusIn("DOCUMENT", allStatuses);
     long coachingTypeCount =
-        contentRepository.countByContentTypeAndStatusIn("COACHING", activeStatuses);
+        contentRepository.countByContentTypeAndStatusIn("COACHING", allStatuses);
     long membershipTypeCount = 0L;
     //        contentRepository.countByContentTypeAndStatusIn("MEMBERSHIP", activeStatuses);
 

--- a/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/AdminSettlementDetailDTO.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/AdminSettlementDetailDTO.java
@@ -1,0 +1,27 @@
+package liaison.groble.application.admin.settlement.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminSettlementDetailDTO {
+  private Long settlementId;
+  // 정산 시작일 (년도 + 월) - Settlement class
+  private LocalDate settlementStartDate;
+  // 정산 종료일 (년도 + 월) - Settlement class
+  private LocalDate settlementEndDate;
+  // 정산(예정)일
+  private LocalDate scheduledSettlementDate;
+  // 정산(예정)금액
+  private BigDecimal settlementAmount; // 정산 예정 금액 (원화 표기)
+  // PG사 수수료(1.7%)
+  private BigDecimal pgFee; // PG사 수수료 (1.7%)
+  // 그로블 수수료(1.5%)
+  private BigDecimal platformFee; // 플랫폼 수수료 (1.5%)
+  // VAT (10%)
+  private BigDecimal vatAmount;
+}

--- a/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/AdminSettlementOverviewDTO.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/AdminSettlementOverviewDTO.java
@@ -1,0 +1,27 @@
+package liaison.groble.application.admin.settlement.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminSettlementOverviewDTO {
+  private Long settlementId;
+  private LocalDate scheduledSettlementDate;
+  private String contentType;
+  private BigDecimal settlementAmount;
+  private String settlementStatus;
+  private String verificationStatus;
+
+  private Boolean isBusinessSeller;
+  private String businessType;
+  private String bankAccountOwner;
+  private String bankName;
+  private String bankAccountNumber;
+  private String copyOfBankbookUrl;
+  private String businessLicenseFileUrl;
+  private String taxInvoiceEmail;
+}

--- a/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/PerTransactionAdminSettlementOverviewDTO.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/PerTransactionAdminSettlementOverviewDTO.java
@@ -1,0 +1,16 @@
+package liaison.groble.application.admin.settlement.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PerTransactionAdminSettlementOverviewDTO {
+  private String contentTitle;
+  private BigDecimal settlementAmount;
+  private String orderStatus;
+  private LocalDateTime purchasedAt;
+}

--- a/groble-application/src/main/java/liaison/groble/application/admin/settlement/service/AdminSettlementService.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/settlement/service/AdminSettlementService.java
@@ -7,9 +7,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.json.simple.JSONObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDTO;
 import liaison.groble.application.admin.settlement.dto.PaypleAccountVerificationRequest;
 import liaison.groble.application.admin.settlement.dto.PayplePartnerAuthResult;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO;
@@ -17,6 +19,7 @@ import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO.Fai
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO.PaypleSettlementResultDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalRequestDTO;
 import liaison.groble.application.payment.exception.PaypleApiException;
+import liaison.groble.common.response.PageResponse;
 import liaison.groble.domain.settlement.entity.Settlement;
 import liaison.groble.domain.settlement.entity.SettlementItem;
 import liaison.groble.domain.settlement.repository.SettlementRepository;
@@ -39,6 +42,15 @@ public class AdminSettlementService {
   private final SettlementRepository settlementRepository;
   private final PaypleSettlementService paypleSettlementService;
   private final PaypleConfig paypleConfig;
+
+  @Transactional(readOnly = true)
+  public PageResponse<AdminSettlementOverviewDTO> getAllUsersSettlements(
+      Long adminUserId, Pageable pageable) {
+
+    log.info("관리자 정산 조회 요청 - 관리자 ID: {}, 페이지: {}", adminUserId, pageable);
+
+    return null;
+  }
 
   /**
    * 정산 승인 처리

--- a/groble-application/src/main/java/liaison/groble/application/admin/settlement/service/AdminSettlementService.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/settlement/service/AdminSettlementService.java
@@ -68,7 +68,18 @@ public class AdminSettlementService {
 
   @Transactional(readOnly = true)
   public AdminSettlementDetailDTO getSettlementDetail(Long settlementId) {
-    return null;
+    Settlement settlement = settlementReader.getSettlementById(settlementId);
+
+    return AdminSettlementDetailDTO.builder()
+        .settlementId(settlement.getId())
+        .settlementStartDate(settlement.getSettlementStartDate())
+        .settlementEndDate(settlement.getSettlementEndDate())
+        .scheduledSettlementDate(settlement.getScheduledSettlementDate())
+        .settlementAmount(settlement.getSettlementAmount())
+        .pgFee(settlement.getPgFee())
+        .platformFee(settlement.getPlatformFee())
+        .vatAmount(settlement.getFeeVat())
+        .build();
   }
 
   /**

--- a/groble-application/src/main/java/liaison/groble/application/admin/settlement/service/AdminSettlementService.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/settlement/service/AdminSettlementService.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import liaison.groble.application.admin.settlement.dto.AdminSettlementDetailDTO;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDTO;
 import liaison.groble.application.admin.settlement.dto.PaypleAccountVerificationRequest;
 import liaison.groble.application.admin.settlement.dto.PayplePartnerAuthResult;
@@ -63,6 +64,11 @@ public class AdminSettlementService {
             .build();
 
     return PageResponse.from(page, items, meta);
+  }
+
+  @Transactional(readOnly = true)
+  public AdminSettlementDetailDTO getSettlementDetail(Long settlementId) {
+    return null;
   }
 
   /**

--- a/groble-application/src/main/java/liaison/groble/application/purchase/service/PurchaseReader.java
+++ b/groble-application/src/main/java/liaison/groble/application/purchase/service/PurchaseReader.java
@@ -95,6 +95,11 @@ public class PurchaseReader {
     return purchaseCustomRepository.getDashboardOverviewStats(sellerId);
   }
 
+  // 관리자 대시보드 개요 조회
+  public FlatDashboardOverviewDTO getAdminDashboardOverviewStats() {
+    return purchaseCustomRepository.getAdminDashboardOverviewStats();
+  }
+
   public boolean isContentPurchasedByUser(Long userId, Long contentId) {
     return purchaseCustomRepository.existsByUserAndContent(userId, contentId);
   }

--- a/groble-application/src/main/java/liaison/groble/application/settlement/reader/SettlementReader.java
+++ b/groble-application/src/main/java/liaison/groble/application/settlement/reader/SettlementReader.java
@@ -103,6 +103,11 @@ public class SettlementReader {
         userId, settlementId, pageable);
   }
 
+  public Page<FlatPerTransactionSettlement> findSalesListBySettlementId(
+      Long settlementId, Pageable pageable) {
+    return settlementCustomRepository.findSalesListBySettlementId(settlementId, pageable);
+  }
+
   public List<Settlement> findAllByUserId(Long userId) {
     return settlementRepository.findAllByUserId(userId);
   }

--- a/groble-application/src/main/java/liaison/groble/application/settlement/reader/SettlementReader.java
+++ b/groble-application/src/main/java/liaison/groble/application/settlement/reader/SettlementReader.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import liaison.groble.common.exception.EntityNotFoundException;
+import liaison.groble.domain.settlement.dto.FlatAdminSettlementsDTO;
 import liaison.groble.domain.settlement.dto.FlatPerTransactionSettlement;
 import liaison.groble.domain.settlement.dto.FlatSettlementsDTO;
 import liaison.groble.domain.settlement.entity.Settlement;
@@ -80,6 +81,11 @@ public class SettlementReader {
 
   public Page<FlatSettlementsDTO> findSettlementsByUserId(Long userId, Pageable pageable) {
     return settlementCustomRepository.findSettlementsByUserId(userId, pageable);
+  }
+
+  public Page<FlatAdminSettlementsDTO> findAdminSettlementsByUserId(
+      Long adminUserId, Pageable pageable) {
+    return settlementCustomRepository.findAdminSettlementsByUserId(adminUserId, pageable);
   }
 
   public Page<FlatPerTransactionSettlement> findPerTransactionSettlementsByIdAndUserId(

--- a/groble-application/src/main/java/liaison/groble/application/settlement/reader/SettlementReader.java
+++ b/groble-application/src/main/java/liaison/groble/application/settlement/reader/SettlementReader.java
@@ -65,6 +65,15 @@ public class SettlementReader {
                         sellerId, settlementId)));
   }
 
+  public Settlement getSettlementById(Long settlementId) {
+    return settlementRepository
+        .findById(settlementId)
+        .orElseThrow(
+            () ->
+                new EntityNotFoundException(
+                    String.format("정산 정보를 찾을 수 없습니다 - settlementId: %d", settlementId)));
+  }
+
   /**
    * 정산 정보 조회 (Optional)
    *

--- a/groble-domain/src/main/java/liaison/groble/domain/content/repository/ContentCustomRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/content/repository/ContentCustomRepository.java
@@ -61,4 +61,12 @@ public interface ContentCustomRepository {
   boolean existsSellingContentByUser(Long userId);
 
   boolean isAvailableForSale(Long contentId);
+
+  long countByStatus(ContentStatus status);
+
+  long countByStatusIn(List<ContentStatus> statuses);
+
+  long countByContentTypeAndStatus(String contentType, ContentStatus status);
+
+  long countByContentTypeAndStatusIn(String contentType, List<ContentStatus> statuses);
 }

--- a/groble-domain/src/main/java/liaison/groble/domain/content/repository/ContentRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/content/repository/ContentRepository.java
@@ -30,4 +30,12 @@ public interface ContentRepository {
   List<Long> findIdsByUserId(Long userId);
 
   boolean existsByUserAndStatus(User user, ContentStatus status);
+
+  long countByStatus(ContentStatus status);
+
+  long countByStatusIn(java.util.List<ContentStatus> statuses);
+
+  long countByContentTypeAndStatus(String contentType, ContentStatus status);
+
+  long countByContentTypeAndStatusIn(String contentType, java.util.List<ContentStatus> statuses);
 }

--- a/groble-domain/src/main/java/liaison/groble/domain/guest/repository/GuestUserRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/guest/repository/GuestUserRepository.java
@@ -15,5 +15,7 @@ public interface GuestUserRepository {
 
   boolean existsByPhoneNumberAndHasCompleteUserInfo(String phoneNumber);
 
+  long count();
+
   GuestUser save(GuestUser guestUser);
 }

--- a/groble-domain/src/main/java/liaison/groble/domain/purchase/repository/PurchaseCustomRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/purchase/repository/PurchaseCustomRepository.java
@@ -43,4 +43,6 @@ public interface PurchaseCustomRepository {
   boolean existsByGuestUserAndContent(Long guestUserId, Long contentId);
 
   FlatDashboardOverviewDTO getDashboardOverviewStats(Long sellerId);
+
+  FlatDashboardOverviewDTO getAdminDashboardOverviewStats();
 }

--- a/groble-domain/src/main/java/liaison/groble/domain/settlement/dto/FlatAdminSettlementsDTO.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/settlement/dto/FlatAdminSettlementsDTO.java
@@ -1,19 +1,25 @@
-package liaison.groble.application.admin.settlement.dto;
+package liaison.groble.domain.settlement.dto;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-public class AdminSettlementOverviewDTO {
+@NoArgsConstructor
+@AllArgsConstructor
+public class FlatAdminSettlementsDTO {
   private Long settlementId;
   private LocalDate scheduledSettlementDate;
   private String contentType;
   private BigDecimal settlementAmount;
   private String settlementStatus;
+
+  // SellerInfo 존재
   private String verificationStatus;
   private Boolean isBusinessSeller;
   private String businessType;

--- a/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementCustomRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementCustomRepository.java
@@ -13,5 +13,8 @@ public interface SettlementCustomRepository {
   Page<FlatPerTransactionSettlement> findPerTransactionSettlementsByIdAndUserId(
       Long userId, Long settlementId, Pageable pageable);
 
+  Page<FlatPerTransactionSettlement> findSalesListBySettlementId(
+      Long settlementId, Pageable pageable);
+
   Page<FlatAdminSettlementsDTO> findAdminSettlementsByUserId(Long adminUserId, Pageable pageable);
 }

--- a/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementCustomRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementCustomRepository.java
@@ -3,9 +3,9 @@ package liaison.groble.domain.settlement.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import liaison.groble.domain.settlement.dto.FlatAdminSettlementsDTO;
 import liaison.groble.domain.settlement.dto.FlatPerTransactionSettlement;
 import liaison.groble.domain.settlement.dto.FlatSettlementsDTO;
-import liaison.groble.domain.settlement.entity.Settlement;
 
 public interface SettlementCustomRepository {
   Page<FlatSettlementsDTO> findSettlementsByUserId(Long userId, Pageable pageable);
@@ -13,11 +13,5 @@ public interface SettlementCustomRepository {
   Page<FlatPerTransactionSettlement> findPerTransactionSettlementsByIdAndUserId(
       Long userId, Long settlementId, Pageable pageable);
 
-  /**
-   * 모든 사용자의 정산 내역 조회 (관리자용)
-   *
-   * @param pageable 페이징 정보
-   * @return 페이징된 정산 목록
-   */
-  Page<Settlement> findAllUsersSettlementsForAdmin(Pageable pageable);
+  Page<FlatAdminSettlementsDTO> findAdminSettlementsByUserId(Long adminUserId, Pageable pageable);
 }

--- a/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementCustomRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementCustomRepository.java
@@ -5,10 +5,19 @@ import org.springframework.data.domain.Pageable;
 
 import liaison.groble.domain.settlement.dto.FlatPerTransactionSettlement;
 import liaison.groble.domain.settlement.dto.FlatSettlementsDTO;
+import liaison.groble.domain.settlement.entity.Settlement;
 
 public interface SettlementCustomRepository {
   Page<FlatSettlementsDTO> findSettlementsByUserId(Long userId, Pageable pageable);
 
   Page<FlatPerTransactionSettlement> findPerTransactionSettlementsByIdAndUserId(
       Long userId, Long settlementId, Pageable pageable);
+
+  /**
+   * 모든 사용자의 정산 내역 조회 (관리자용)
+   *
+   * @param pageable 페이징 정보
+   * @return 페이징된 정산 목록
+   */
+  Page<Settlement> findAllUsersSettlementsForAdmin(Pageable pageable);
 }

--- a/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementRepository.java
@@ -13,6 +13,8 @@ public interface SettlementRepository {
 
   Optional<Settlement> findByIdAndUserId(Long sellerId, Long settlementId);
 
+  Optional<Settlement> findById(Long settlementId);
+
   BigDecimal getPendingSettlementAmount(Long sellerId);
 
   List<Settlement> findAllByUserId(Long userId);

--- a/groble-domain/src/main/java/liaison/groble/domain/user/repository/UserRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/user/repository/UserRepository.java
@@ -14,5 +14,7 @@ public interface UserRepository {
 
   boolean existsByNicknameAndStatus(String nickname, UserStatus status);
 
+  long countByStatus(UserStatus status);
+
   User saveAndFlush(User user);
 }

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/content/ContentCustomRepositoryImpl.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/content/ContentCustomRepositoryImpl.java
@@ -997,4 +997,62 @@ public class ContentCustomRepositoryImpl implements ContentCustomRepository {
 
     return result != null;
   }
+
+  @Override
+  public long countByStatus(ContentStatus status) {
+    QContent qContent = QContent.content;
+    return Optional.ofNullable(
+            queryFactory
+                .select(qContent.count())
+                .from(qContent)
+                .where(qContent.status.eq(status))
+                .fetchOne())
+        .orElse(0L);
+  }
+
+  @Override
+  public long countByStatusIn(List<ContentStatus> statuses) {
+    QContent qContent = QContent.content;
+    return Optional.ofNullable(
+            queryFactory
+                .select(qContent.count())
+                .from(qContent)
+                .where(qContent.status.in(statuses))
+                .fetchOne())
+        .orElse(0L);
+  }
+
+  @Override
+  public long countByContentTypeAndStatus(String contentType, ContentStatus status) {
+    QContent qContent = QContent.content;
+    return Optional.ofNullable(
+            queryFactory
+                .select(qContent.count())
+                .from(qContent)
+                .where(
+                    qContent
+                        .contentType
+                        .stringValue()
+                        .eq(contentType)
+                        .and(qContent.status.eq(status)))
+                .fetchOne())
+        .orElse(0L);
+  }
+
+  @Override
+  public long countByContentTypeAndStatusIn(String contentType, List<ContentStatus> statuses) {
+    QContent qContent = QContent.content;
+    return Optional.ofNullable(
+            queryFactory
+                .select(qContent.count())
+                .from(qContent)
+                .where(
+                    qContent
+                        .contentType
+                        .stringValue()
+                        .eq(contentType)
+                        .and(qContent.status.in(statuses)))
+                .fetchOne())
+        .orElse(0L);
+  }
 }

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/content/ContentRepositoryImpl.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/content/ContentRepositoryImpl.java
@@ -65,6 +65,26 @@ public class ContentRepositoryImpl implements ContentRepository {
     return jpaContentRepository.findIdsByUserId(userId);
   }
 
+  @Override
+  public long countByStatus(ContentStatus status) {
+    return contentCustomRepository.countByStatus(status);
+  }
+
+  @Override
+  public long countByStatusIn(List<ContentStatus> statuses) {
+    return contentCustomRepository.countByStatusIn(statuses);
+  }
+
+  @Override
+  public long countByContentTypeAndStatus(String contentType, ContentStatus status) {
+    return contentCustomRepository.countByContentTypeAndStatus(contentType, status);
+  }
+
+  @Override
+  public long countByContentTypeAndStatusIn(String contentType, List<ContentStatus> statuses) {
+    return contentCustomRepository.countByContentTypeAndStatusIn(contentType, statuses);
+  }
+
   public boolean existsSellingContentByUser(Long userId) {
     return contentCustomRepository.existsSellingContentByUser(userId);
   }

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/guest/GuestUserRepositoryImpl.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/guest/GuestUserRepositoryImpl.java
@@ -40,6 +40,11 @@ public class GuestUserRepositoryImpl implements GuestUserRepository {
   }
 
   @Override
+  public long count() {
+    return jpaGuestUserRepository.count();
+  }
+
+  @Override
   public GuestUser save(GuestUser guestUser) {
     return jpaGuestUserRepository.save(guestUser);
   }

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/guest/JpaGuestUserRepository.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/guest/JpaGuestUserRepository.java
@@ -21,5 +21,7 @@ public interface JpaGuestUserRepository extends JpaRepository<GuestUser, Long> {
       "SELECT COUNT(gu) > 0 FROM GuestUser gu WHERE gu.phoneNumber = :phoneNumber AND gu.email IS NOT NULL AND gu.email != '' AND gu.username IS NOT NULL AND gu.username != ''")
   boolean existsByPhoneNumberAndHasCompleteUserInfo(@Param("phoneNumber") String phoneNumber);
 
+  long count();
+
   GuestUser save(GuestUser guestUser);
 }

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/settlement/JpaSettlementRepository.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/settlement/JpaSettlementRepository.java
@@ -26,6 +26,8 @@ public interface JpaSettlementRepository extends JpaRepository<Settlement, Long>
   Optional<Settlement> findByIdAndUserId(
       @Param("userId") Long userId, @Param("settlementId") Long settlementId);
 
+  Optional<Settlement> findById(Long settlementId);
+
   @Query(
       "SELECT COALESCE(SUM(s.settlementAmount), 0) FROM Settlement s "
           + "WHERE s.user.id = :sellerId "

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/settlement/SettlementCustomRepositoryImpl.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/settlement/SettlementCustomRepositoryImpl.java
@@ -17,13 +17,14 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import liaison.groble.domain.order.entity.QOrder;
 import liaison.groble.domain.purchase.entity.QPurchase;
+import liaison.groble.domain.settlement.dto.FlatAdminSettlementsDTO;
 import liaison.groble.domain.settlement.dto.FlatPerTransactionSettlement;
 import liaison.groble.domain.settlement.dto.FlatSettlementsDTO;
 import liaison.groble.domain.settlement.entity.QSettlement;
 import liaison.groble.domain.settlement.entity.QSettlementItem;
-import liaison.groble.domain.settlement.entity.Settlement;
 import liaison.groble.domain.settlement.enums.SettlementType;
 import liaison.groble.domain.settlement.repository.SettlementCustomRepository;
+import liaison.groble.domain.user.entity.QSellerInfo;
 import liaison.groble.domain.user.entity.QUser;
 
 import lombok.RequiredArgsConstructor;
@@ -94,8 +95,8 @@ public class SettlementCustomRepositoryImpl implements SettlementCustomRepositor
 
     QSettlementItem qSettlementItem = QSettlementItem.settlementItem;
     QSettlement qSettlement = QSettlement.settlement;
-    QPurchase qPurchase = QPurchase.purchase; // 선택: 모델에 맞게 사용
-    QOrder qOrder = QOrder.order; // 선택: 모델에 맞게 사용
+    QPurchase qPurchase = QPurchase.purchase;
+    QOrder qOrder = QOrder.order;
 
     // [기간] purchasedAt ∈ [periodStart 00:00, periodEnd+1 00:00)
     BooleanExpression cond =
@@ -139,31 +140,65 @@ public class SettlementCustomRepositoryImpl implements SettlementCustomRepositor
   }
 
   @Override
-  public Page<Settlement> findAllUsersSettlementsForAdmin(Pageable pageable) {
+  public Page<FlatAdminSettlementsDTO> findAdminSettlementsByUserId(
+      Long adminUserId, Pageable pageable) {
     QSettlement qSettlement = QSettlement.settlement;
     QUser qUser = QUser.user;
+    QSellerInfo qSellerInfo = QSellerInfo.sellerInfo;
 
-    // 메인 쿼리 - Settlement 엔터티를 직접 조회하고 User 정보를 fetch join
-    JPAQuery<Settlement> query =
+    // settlementType에 따른 정렬 우선순위 설정 (COACHING = 0, DOCUMENT = 1)
+    NumberExpression<Integer> typeOrder =
+        new CaseBuilder()
+            .when(qSettlement.settlementType.eq(SettlementType.COACHING))
+            .then(0)
+            .when(qSettlement.settlementType.eq(SettlementType.DOCUMENT))
+            .then(1)
+            .otherwise(2);
+
+    JPAQuery<FlatAdminSettlementsDTO> query =
         jpaQueryFactory
-            .selectFrom(qSettlement)
+            .select(
+                Projections.fields(
+                    FlatAdminSettlementsDTO.class,
+                    qSettlement.id.as("settlementId"),
+                    qSettlement.scheduledSettlementDate.as("scheduledSettlementDate"),
+                    qSettlement.settlementType.stringValue().as("contentType"),
+                    qSettlement.settlementAmount.as("settlementAmount"),
+                    qSettlement.status.stringValue().as("settlementStatus"),
+                    // SellerInfo 필드들
+                    qSellerInfo.verificationStatus.stringValue().as("verificationStatus"),
+                    qSellerInfo.isBusinessSeller.as("isBusinessSeller"),
+                    qSellerInfo.businessType.stringValue().as("businessType"),
+                    qSellerInfo.bankAccountOwner.as("bankAccountOwner"),
+                    qSellerInfo.bankName.as("bankName"),
+                    qSellerInfo.bankAccountNumber.as("bankAccountNumber"),
+                    qSellerInfo.copyOfBankbookUrl.as("copyOfBankbookUrl"),
+                    qSellerInfo.businessLicenseFileUrl.as("businessLicenseFileUrl"),
+                    qSellerInfo.taxInvoiceEmail.as("taxInvoiceEmail")))
+            .from(qSettlement)
             .leftJoin(qSettlement.user, qUser)
-            .fetchJoin()
+            .leftJoin(qSellerInfo)
+            .on(qSellerInfo.user.eq(qUser))
             .orderBy(
                 qSettlement.scheduledSettlementDate.desc(), // 정산 예정일 기준 정렬
-                qSettlement.createdAt.desc() // 생성일 기준 정렬
+                typeOrder.asc(), // COACHING이 먼저 (0 < 1)
+                qSettlement.id.desc() // tie-breaker
                 );
 
-    // 페이징 적용
-    List<Settlement> content =
+    List<FlatAdminSettlementsDTO> items =
         query.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
 
-    // 전체 카운트 조회
     long total =
         Optional.ofNullable(
-                jpaQueryFactory.select(qSettlement.count()).from(qSettlement).fetchOne())
+                jpaQueryFactory
+                    .select(qSettlement.count())
+                    .from(qSettlement)
+                    .leftJoin(qSettlement.user, qUser)
+                    .leftJoin(qSellerInfo)
+                    .on(qSellerInfo.user.eq(qUser))
+                    .fetchOne())
             .orElse(0L);
 
-    return new PageImpl<>(content, pageable, total);
+    return new PageImpl<>(items, pageable, total);
   }
 }

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/settlement/SettlementRepositoryImpl.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/settlement/SettlementRepositoryImpl.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import liaison.groble.domain.settlement.entity.Settlement;
+import liaison.groble.domain.settlement.repository.SettlementCustomRepository;
 import liaison.groble.domain.settlement.repository.SettlementRepository;
 
 import lombok.AllArgsConstructor;
@@ -16,6 +17,7 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class SettlementRepositoryImpl implements SettlementRepository {
   private final JpaSettlementRepository jpaSettlementRepository;
+  private final SettlementCustomRepository settlementCustomRepository;
 
   @Override
   public Optional<Settlement> findByUserIdAndPeriod(

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/settlement/SettlementRepositoryImpl.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/settlement/SettlementRepositoryImpl.java
@@ -31,6 +31,11 @@ public class SettlementRepositoryImpl implements SettlementRepository {
   }
 
   @Override
+  public Optional<Settlement> findById(Long settlementId) {
+    return jpaSettlementRepository.findById(settlementId);
+  }
+
+  @Override
   public BigDecimal getPendingSettlementAmount(Long sellerId) {
     return jpaSettlementRepository.calculatePendingSettlementAmount(sellerId);
   }

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/user/JpaUserRepository.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/user/JpaUserRepository.java
@@ -17,4 +17,6 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
   boolean existsByUserProfileNicknameAndUserStatusInfo_Status(String nickname, UserStatus status);
 
   boolean existsByUserProfilePhoneNumber(String phoneNumber);
+
+  long countByUserStatusInfo_Status(UserStatus status);
 }

--- a/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/user/UserRepositoryImpl.java
+++ b/groble-infrastructure/groble-persistence/src/main/java/liaison/groble/persistence/user/UserRepositoryImpl.java
@@ -38,6 +38,11 @@ public class UserRepositoryImpl implements UserRepository {
   }
 
   @Override
+  public long countByStatus(UserStatus status) {
+    return jpaUserRepository.countByUserStatusInfo_Status(status);
+  }
+
+  @Override
   @Transactional
   public User saveAndFlush(User user) {
     return jpaUserRepository.saveAndFlush(user);

--- a/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminDashboardMapper.java
+++ b/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminDashboardMapper.java
@@ -2,7 +2,13 @@ package liaison.groble.mapping.admin;
 
 import org.mapstruct.Mapper;
 
+import liaison.groble.api.model.admin.dashboard.response.AdminDashboardOverviewResponse;
+import liaison.groble.application.admin.dashboard.dto.AdminDashboardOverviewDTO;
 import liaison.groble.mapping.config.GrobleMapperConfig;
 
 @Mapper(config = GrobleMapperConfig.class)
-public interface AdminDashboardMapper {}
+public interface AdminDashboardMapper {
+
+  AdminDashboardOverviewResponse toAdminDashboardOverviewResponse(
+      AdminDashboardOverviewDTO adminDashboardOverviewDTO);
+}

--- a/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminDashboardMapper.java
+++ b/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminDashboardMapper.java
@@ -1,0 +1,8 @@
+package liaison.groble.mapping.admin;
+
+import org.mapstruct.Mapper;
+
+import liaison.groble.mapping.config.GrobleMapperConfig;
+
+@Mapper(config = GrobleMapperConfig.class)
+public interface AdminDashboardMapper {}

--- a/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminSettlementMapper.java
+++ b/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminSettlementMapper.java
@@ -4,8 +4,10 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import liaison.groble.api.model.admin.settlement.request.SettlementApprovalRequest;
+import liaison.groble.api.model.admin.settlement.response.AdminSettlementDetailResponse;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.SettlementApprovalResponse;
+import liaison.groble.application.admin.settlement.dto.AdminSettlementDetailDTO;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalRequestDTO;
@@ -32,6 +34,9 @@ public interface AdminSettlementMapper extends PageResponseMapper {
 
   AdminSettlementsOverviewResponse toAdminSettlementsOverviewResponse(
       AdminSettlementOverviewDTO adminSettlementOverviewDTO);
+
+  AdminSettlementDetailResponse toAdminSettlementDetailResponse(
+      AdminSettlementDetailDTO adminSettlementDetailDTO);
 
   /** PaypleSettlementResultDTO 매핑 */
   SettlementApprovalResponse.PaypleSettlementResult toPaypleResult(

--- a/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminSettlementMapper.java
+++ b/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminSettlementMapper.java
@@ -4,13 +4,17 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import liaison.groble.api.model.admin.settlement.request.SettlementApprovalRequest;
+import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.SettlementApprovalResponse;
+import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalRequestDTO;
+import liaison.groble.common.response.PageResponse;
+import liaison.groble.mapping.common.PageResponseMapper;
 import liaison.groble.mapping.config.GrobleMapperConfig;
 
 @Mapper(config = GrobleMapperConfig.class)
-public interface AdminSettlementMapper {
+public interface AdminSettlementMapper extends PageResponseMapper {
 
   /** API 요청을 Application DTO로 변환 */
   SettlementApprovalRequestDTO toRequestDTO(SettlementApprovalRequest request);
@@ -19,6 +23,15 @@ public interface AdminSettlementMapper {
   @Mapping(target = "paypleResult", source = "paypleResult")
   @Mapping(target = "failedSettlements", source = "failedSettlements")
   SettlementApprovalResponse toResponse(SettlementApprovalDTO dto);
+
+  // ====== 📤 PageResponse 변환 ======
+  default PageResponse<AdminSettlementsOverviewResponse> toAdminSettlementsOverviewResponsePage(
+      PageResponse<AdminSettlementOverviewDTO> dtoPage) {
+    return toPageResponse(dtoPage, this::toAdminSettlementsOverviewResponse);
+  }
+
+  AdminSettlementsOverviewResponse toAdminSettlementsOverviewResponse(
+      AdminSettlementOverviewDTO adminSettlementOverviewDTO);
 
   /** PaypleSettlementResultDTO 매핑 */
   SettlementApprovalResponse.PaypleSettlementResult toPaypleResult(

--- a/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminSettlementMapper.java
+++ b/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminSettlementMapper.java
@@ -6,9 +6,11 @@ import org.mapstruct.Mapping;
 import liaison.groble.api.model.admin.settlement.request.SettlementApprovalRequest;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementDetailResponse;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
+import liaison.groble.api.model.admin.settlement.response.PerTransactionAdminSettlementOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.SettlementApprovalResponse;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementDetailDTO;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDTO;
+import liaison.groble.application.admin.settlement.dto.PerTransactionAdminSettlementOverviewDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalRequestDTO;
 import liaison.groble.common.response.PageResponse;
@@ -32,11 +34,20 @@ public interface AdminSettlementMapper extends PageResponseMapper {
     return toPageResponse(dtoPage, this::toAdminSettlementsOverviewResponse);
   }
 
+  default PageResponse<PerTransactionAdminSettlementOverviewResponse>
+      toPerTransactionAdminSettlementOverviewResponsePage(
+          PageResponse<PerTransactionAdminSettlementOverviewDTO> dtoPage) {
+    return toPageResponse(dtoPage, this::toPerTransactionAdminSettlementOverviewResponse);
+  }
+
   AdminSettlementsOverviewResponse toAdminSettlementsOverviewResponse(
       AdminSettlementOverviewDTO adminSettlementOverviewDTO);
 
   AdminSettlementDetailResponse toAdminSettlementDetailResponse(
       AdminSettlementDetailDTO adminSettlementDetailDTO);
+
+  PerTransactionAdminSettlementOverviewResponse toPerTransactionAdminSettlementOverviewResponse(
+      PerTransactionAdminSettlementOverviewDTO perTransactionAdminSettlementOverviewDTO);
 
   /** PaypleSettlementResultDTO 매핑 */
   SettlementApprovalResponse.PaypleSettlementResult toPaypleResult(


### PR DESCRIPTION
## 1. 관리자 대시보드 기능
### 대시보드 개요 조회 API: 플랫폼 전체 운영 지표를 한눈에 확인
- 총 거래액 및 거래 건수 (전체/월별)
- 회원/비회원 사용자 통계
- 콘텐츠 현황 (전체/판매중)
- 콘텐츠 유형별 분포 (자료/서비스/멤버십)
- Swagger 문서화: 대시보드 관련 API 명세 추가

### 2. 정산 관리 시스템
- 전체 사용자 정산 내역 조회
   - 페이징 처리를 통한 대용량 데이터 효율적 조회
- 정산 상세 내역 조회
   - 개별 정산 건에 대한 상세 정보 제공
   - 판매자 정보, 금액, 처리 상태 등 포함
- 총 판매 내역 조회
   - 전체 판매 데이터 통합 조회
