### PR TITLE
hotfix: 결제 취소 중복 처리 및 카카오뱅크 기관 코드 누락 수정

### DIFF
--- a/groble-api/groble-api-server/src/main/resources/application-dev.yml
+++ b/groble-api/groble-api-server/src/main/resources/application-dev.yml
@@ -175,7 +175,7 @@ logging:
 # OpenTelemetry 설정 활성화
 otel:
   service:
-    name: "groble-api"
+    name: "groble-dev-api"
     version: "1.0.0"
   exporter:
     otlp:
@@ -187,7 +187,7 @@ otel:
       compression: "gzip"
   resource:
     attributes:
-      service.name: "groble-api"
+      service.name: "groble-dev-api"
       service.version: "1.0.0"
       environment: "development"
       deployment.environment: "dev"

--- a/groble-application/src/main/java/liaison/groble/application/auth/util/BankCodeUtil.java
+++ b/groble-application/src/main/java/liaison/groble/application/auth/util/BankCodeUtil.java
@@ -28,6 +28,7 @@ public final class BankCodeUtil {
 
     // 인터넷 전문은행
     BANK_CODE_MAP.put("케이뱅크", "089");
+    BANK_CODE_MAP.put("카카오뱅크", "090");
     BANK_CODE_MAP.put("토스뱅크", "092");
 
     // 특수은행 및 농협

--- a/groble-application/src/main/java/liaison/groble/application/payment/exception/refund/DuplicateCancelRequestException.java
+++ b/groble-application/src/main/java/liaison/groble/application/payment/exception/refund/DuplicateCancelRequestException.java
@@ -1,0 +1,18 @@
+package liaison.groble.application.payment.exception.refund;
+
+import liaison.groble.application.payment.exception.PaymentException;
+
+import lombok.Getter;
+
+/** 중복 취소 요청에 대한 예외 클래스 이미 취소 요청된 주문에 대해 재요청이 올 경우 발생 */
+@Getter
+public class DuplicateCancelRequestException extends PaymentException {
+  private final String orderId;
+  private final String orderStatus;
+
+  public DuplicateCancelRequestException(String message, String orderId, String orderStatus) {
+    super(message);
+    this.orderId = orderId;
+    this.orderStatus = orderStatus;
+  }
+}

--- a/groble-application/src/main/java/liaison/groble/application/payment/service/PaymentService.java
+++ b/groble-application/src/main/java/liaison/groble/application/payment/service/PaymentService.java
@@ -100,9 +100,7 @@ public class PaymentService {
     // 이미 취소 요청된 경우 - 중복 요청 예외 처리
     if (order.getStatus() == Order.OrderStatus.CANCEL_REQUEST) {
       throw new DuplicateCancelRequestException(
-          "이미 취소 요청이 진행 중입니다. 중복 요청은 처리할 수 없습니다.",
-          String.valueOf(order.getId()),
-          order.getStatus().toString());
+          "결제 취소 요청이 아마 완료된 콘텐츠입니다", String.valueOf(order.getId()), order.getStatus().toString());
     }
 
     // 결제 완료 상태가 아닌 경우

--- a/groble-application/src/main/java/liaison/groble/application/payment/service/PaymentService.java
+++ b/groble-application/src/main/java/liaison/groble/application/payment/service/PaymentService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import liaison.groble.application.order.service.OrderReader;
 import liaison.groble.application.payment.dto.cancel.PaymentCancelDTO;
 import liaison.groble.application.payment.dto.cancel.PaymentCancelInfoDTO;
+import liaison.groble.application.payment.exception.refund.DuplicateCancelRequestException;
 import liaison.groble.application.payment.exception.refund.OrderCancellationException;
 import liaison.groble.application.payment.exception.refund.PaymentRefundBadRequestException;
 import liaison.groble.application.purchase.service.PurchaseReader;
@@ -96,10 +97,12 @@ public class PaymentService {
   }
 
   private void validateRequestCancellableStatus(Order order) {
-    // 이미 취소 요청된 경우
+    // 이미 취소 요청된 경우 - 중복 요청 예외 처리
     if (order.getStatus() == Order.OrderStatus.CANCEL_REQUEST) {
-      throw new OrderCancellationException(
-          "이미 취소 요청이 완료되었습니다.", String.valueOf(order.getId()), order.getStatus().toString());
+      throw new DuplicateCancelRequestException(
+          "이미 취소 요청이 진행 중입니다. 중복 요청은 처리할 수 없습니다.",
+          String.valueOf(order.getId()),
+          order.getStatus().toString());
     }
 
     // 결제 완료 상태가 아닌 경우


### PR DESCRIPTION
### 결제 취소 처리 개선
- 결제 취소 재요청에 대한 커스텀 에러 추가
- 중복 요청 에러 문구 수정

### 카카오뱅크 기관 코드 누락 수정
- BankCodeUtil에 카카오뱅크 추가