### PR TITLE
fix: 비회원 결제 발생 시에 판매자/구매자 알림톡 발송 오류 수정

### DIFF
--- a/groble-application/src/main/java/liaison/groble/application/order/service/OrderService.java
+++ b/groble-application/src/main/java/liaison/groble/application/order/service/OrderService.java
@@ -471,10 +471,14 @@ public class OrderService {
 
       // 회원/비회원에 따른 정보 설정
       if (order.isMemberOrder()) {
-        resultBuilder.userId(order.getUser().getId()).nickname(order.getUser().getNickname());
+        resultBuilder
+            .userId(order.getUser().getId())
+            .guestUserId(null)
+            .nickname(order.getUser().getNickname());
       } else if (order.isGuestOrder()) {
         resultBuilder
             .userId(null) // 비회원은 userId가 없음
+            .guestUserId(order.getGuestUser().getId())
             .nickname(order.getGuestUser().getUsername()); // GuestUser의 username 사용
       }
 
@@ -488,7 +492,7 @@ public class OrderService {
           order.getId(),
           freePayment.getId(),
           purchase.getId(),
-          order.getUser().getId(),
+          order.isMemberOrder() && order.getUser() != null ? order.getUser().getId() : null,
           purchase.getContent().getId());
 
       return true;
@@ -867,6 +871,7 @@ public class OrderService {
               .paymentId(freePaymentCompletionResult.getPaymentId())
               .purchaseId(freePaymentCompletionResult.getPurchaseId())
               .userId(freePaymentCompletionResult.getUserId())
+              .guestUserId(freePaymentCompletionResult.getGuestUserId())
               .contentId(freePaymentCompletionResult.getContentId())
               .sellerId(freePaymentCompletionResult.getSellerId())
               .amount(freePaymentCompletionResult.getAmount())

--- a/groble-application/src/main/java/liaison/groble/application/order/strategy/BaseOrderProcessor.java
+++ b/groble-application/src/main/java/liaison/groble/application/order/strategy/BaseOrderProcessor.java
@@ -308,10 +308,14 @@ public abstract class BaseOrderProcessor implements OrderProcessorStrategy {
 
       // 회원/비회원에 따른 정보 설정
       if (order.isMemberOrder()) {
-        resultBuilder.userId(order.getUser().getId()).nickname(order.getUser().getNickname());
+        resultBuilder
+            .userId(order.getUser().getId())
+            .guestUserId(null)
+            .nickname(order.getUser().getNickname());
       } else if (order.isGuestOrder()) {
         resultBuilder
             .userId(null) // 비회원은 userId가 없음
+            .guestUserId(order.getGuestUser().getId())
             .nickname(order.getGuestUser().getUsername()); // GuestUser의 username 사용
       }
 
@@ -442,6 +446,7 @@ public abstract class BaseOrderProcessor implements OrderProcessorStrategy {
               .paymentId(freePaymentCompletionResult.getPaymentId())
               .purchaseId(freePaymentCompletionResult.getPurchaseId())
               .userId(freePaymentCompletionResult.getUserId())
+              .guestUserId(freePaymentCompletionResult.getGuestUserId())
               .contentId(freePaymentCompletionResult.getContentId())
               .sellerId(freePaymentCompletionResult.getSellerId())
               .amount(freePaymentCompletionResult.getAmount())

--- a/groble-application/src/main/java/liaison/groble/application/payment/dto/completion/FreePaymentCompletionResult.java
+++ b/groble-application/src/main/java/liaison/groble/application/payment/dto/completion/FreePaymentCompletionResult.java
@@ -15,6 +15,7 @@ public class FreePaymentCompletionResult {
   private final Long paymentId;
   private final Long purchaseId;
   private final Long userId;
+  private final Long guestUserId;
   private final Long contentId;
   private final Long sellerId;
   private final BigDecimal amount;

--- a/groble-application/src/main/java/liaison/groble/application/payment/event/FreePaymentCompletedEvent.java
+++ b/groble-application/src/main/java/liaison/groble/application/payment/event/FreePaymentCompletedEvent.java
@@ -19,6 +19,7 @@ public class FreePaymentCompletedEvent {
   private Long paymentId;
   private Long purchaseId;
   private Long userId;
+  private Long guestUserId;
   private Long contentId;
   private Long sellerId;
   private BigDecimal amount;


### PR DESCRIPTION
  - API 모델/DTO/서비스/Redis 어댑터 전반을 verificationToken 기반으로 재설계 (홈 테스트 전화 인증).
  - 결제 완료 이벤트(PaymentCompletedEvent, FreePaymentCompletedEvent)에 비회원 ID를 포함시키고 발행부 업데이트.
  - PaymentNotificationService:
      - 판매자/구매자 알림 발송 시 ID 누락을 선제적으로 스킵하고, 카카오 알림은 회원/비회원 각각에 맞춰 발송.
      - 비회원 구매자 이름 처리 유틸 추가 및 로그 메시지 정리.