### PR TITLE
[Feature/Admin-#168] 정산지급대행 자동화 기능 추가

### DIFF
--- a/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/AdminSettlementDetailResponse.java
+++ b/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/AdminSettlementDetailResponse.java
@@ -204,4 +204,11 @@ public class AdminSettlementDetailResponse {
       type = "number",
       requiredMode = Schema.RequiredMode.REQUIRED)
   private BigDecimal vatRate;
+
+  @Schema(
+      description = "정산 비고(페이플 응답 등 관리자 참고 메모)",
+      example = "Payple SUCCESS - code: A0000, message: 승인완료",
+      type = "string",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  private String settlementNote;
 }

--- a/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/PgFeeAdjustmentResponse.java
+++ b/groble-api/groble-api-model/src/main/java/liaison/groble/api/model/admin/settlement/response/PgFeeAdjustmentResponse.java
@@ -1,0 +1,92 @@
+package liaison.groble.api.model.admin.settlement.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "[✅ 관리자 페이지 - 정산 관리] PG 수수료 차액 내역 응답")
+public class PgFeeAdjustmentResponse {
+
+  @Schema(description = "정산 ID", example = "123")
+  private Long settlementId;
+
+  @Schema(description = "정산 항목 ID", example = "456")
+  private Long settlementItemId;
+
+  @Schema(description = "구매 ID", example = "789")
+  private Long purchaseId;
+
+  @Schema(description = "판매자 ID", example = "42")
+  private Long sellerId;
+
+  @Schema(description = "판매자 닉네임", example = "groble_maker")
+  private String sellerNickname;
+
+  @Schema(description = "주문 고유번호 (Merchant UID)", example = "ORD-20250201-00001")
+  private String merchantUid;
+
+  @Schema(description = "콘텐츠 제목", example = "AI 툴 개발 가이드")
+  private String contentTitle;
+
+  @Schema(description = "총 판매 금액", example = "150000.00")
+  private BigDecimal salesAmount;
+
+  @Schema(description = "적용된 PG 수수료 (실제 2.9%)", example = "4350.00")
+  private BigDecimal pgFeeApplied;
+
+  @Schema(description = "표시된 PG 수수료 (기준 1.7%)", example = "2550.00")
+  private BigDecimal pgFeeDisplay;
+
+  @Schema(description = "PG 수수료 차액 (2.9% - 1.7%)", example = "1800.00")
+  private BigDecimal pgFeeDifference;
+
+  @Schema(description = "적용된 수수료 VAT", example = "435.00")
+  private BigDecimal feeVat;
+
+  @Schema(description = "표시된 수수료 VAT", example = "255.00")
+  private BigDecimal feeVatDisplay;
+
+  @Schema(description = "VAT 차액", example = "180.00")
+  private BigDecimal feeVatDifference;
+
+  @Schema(description = "환급 예상 PG 수수료(차액 + VAT)", example = "1980.00")
+  private BigDecimal pgFeeRefundExpected;
+
+  @Schema(description = "적용된 총 수수료", example = "4785.00")
+  private BigDecimal totalFee;
+
+  @Schema(description = "표시된 총 수수료", example = "2805.00")
+  private BigDecimal totalFeeDisplay;
+
+  @Schema(description = "적용된 정산 금액", example = "145215.00")
+  private BigDecimal settlementAmount;
+
+  @Schema(description = "표시된 정산 금액", example = "147195.00")
+  private BigDecimal settlementAmountDisplay;
+
+  @Schema(description = "구매 일시", example = "2025-02-01 12:34:56")
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+  private LocalDateTime purchasedAt;
+
+  @Schema(description = "주문 상태 [PAID, CANCEL_REQUEST, CANCELLED]", example = "PAID")
+  private String orderStatus;
+
+  @Schema(description = "적용된 PG 수수료율", example = "0.0290")
+  private BigDecimal capturedPgFeeRate;
+
+  @Schema(description = "표시된 PG 수수료율", example = "0.0170")
+  private BigDecimal capturedPgFeeRateDisplay;
+
+  @Schema(description = "기준 PG 수수료율", example = "0.0170")
+  private BigDecimal capturedPgFeeRateBaseline;
+
+  @Schema(description = "적용된 VAT율", example = "0.1000")
+  private BigDecimal capturedVatRate;
+}

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/AdminSettlementController.java
@@ -1,8 +1,11 @@
 package liaison.groble.api.server.admin;
 
+import java.time.LocalDate;
+
 import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +20,7 @@ import liaison.groble.api.model.admin.settlement.request.SettlementApprovalReque
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementDetailResponse;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.PerTransactionAdminSettlementOverviewResponse;
+import liaison.groble.api.model.admin.settlement.response.PgFeeAdjustmentResponse;
 import liaison.groble.api.model.admin.settlement.response.SettlementApprovalResponse;
 import liaison.groble.api.server.admin.docs.AdminSettlementApiResponses;
 import liaison.groble.api.server.admin.docs.AdminSettlementExampleResponses;
@@ -27,6 +31,7 @@ import liaison.groble.api.server.common.ResponseMessages;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementDetailDTO;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDTO;
 import liaison.groble.application.admin.settlement.dto.PerTransactionAdminSettlementOverviewDTO;
+import liaison.groble.application.admin.settlement.dto.PgFeeAdjustmentDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalRequestDTO;
 import liaison.groble.application.admin.settlement.service.AdminSettlementService;
@@ -165,6 +170,41 @@ public class AdminSettlementController extends BaseController {
         adminSettlementMapper.toPerTransactionAdminSettlementOverviewResponsePage(dtoPage);
 
     return success(responsePage, ResponseMessages.Admin.SALES_LIST_RETRIEVED);
+  }
+
+  @Operation(
+      summary = AdminSettlementSwaggerDocs.PG_FEE_ADJUSTMENTS_SUMMARY,
+      description = AdminSettlementSwaggerDocs.PG_FEE_ADJUSTMENTS_DESCRIPTION)
+  @AdminSettlementExampleResponses.PgFeeAdjustmentsSuccess
+  @RequireRole("ROLE_ADMIN")
+  @Logging(
+      item = "AdminSettlement",
+      action = "getPgFeeAdjustments",
+      includeParam = true,
+      includeResult = true)
+  @GetMapping(ApiPaths.Admin.PG_FEE_ADJUSTMENTS)
+  public ResponseEntity<GrobleResponse<PageResponse<PgFeeAdjustmentResponse>>> getPgFeeAdjustments(
+      @Auth Accessor accessor,
+      @RequestParam(value = "startDate", required = false)
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate startDate,
+      @RequestParam(value = "endDate", required = false)
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate endDate,
+      @RequestParam(value = "settlementId", required = false) Long settlementId,
+      @RequestParam(value = "sellerId", required = false) Long sellerId,
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "20") int size,
+      @RequestParam(value = "sort", defaultValue = "purchasedAt,desc") String sort) {
+
+    Pageable pageable = PageUtils.createPageable(page, size, sort);
+    PageResponse<PgFeeAdjustmentDTO> dtoPage =
+        adminSettlementService.getPgFeeAdjustments(
+            startDate, endDate, settlementId, sellerId, pageable);
+    PageResponse<PgFeeAdjustmentResponse> responsePage =
+        adminSettlementMapper.toPgFeeAdjustmentResponsePage(dtoPage);
+
+    return success(responsePage, ResponseMessages.Admin.PG_FEE_ADJUSTMENTS_RETRIEVED);
   }
 
   /**

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExampleResponses.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExampleResponses.java
@@ -173,4 +173,53 @@ public final class AdminSettlementExampleResponses {
                         value = CommonSwaggerDocs.SERVER_ERROR_EXAMPLE)))
   })
   public @interface AdminSettlementSalesListSuccess {}
+
+  /** 관리자 PG 수수료 차액 조회 성공 응답 */
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = CommonSwaggerDocs.SUCCESS_200,
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema =
+                    @Schema(
+                        implementation =
+                            AdminResponseSchemas.ApiAdminPgFeeAdjustmentsResponse.class),
+                examples =
+                    @ExampleObject(
+                        name = "성공 응답 예시",
+                        description = "PG 수수료 차액 조회 성공 시 응답 예시",
+                        value = AdminSettlementExamples.PG_FEE_ADJUSTMENTS_SUCCESS_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "403",
+        description = CommonSwaggerDocs.FORBIDDEN,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.FORBIDDEN_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "404",
+        description = CommonSwaggerDocs.NOT_FOUND,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.NOT_FOUND_EXAMPLE))),
+    @ApiResponse(
+        responseCode = "500",
+        description = CommonSwaggerDocs.SERVER_ERROR,
+        content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                        value = CommonSwaggerDocs.SERVER_ERROR_EXAMPLE)))
+  })
+  public @interface PgFeeAdjustmentsSuccess {}
 }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExamples.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementExamples.java
@@ -106,7 +106,8 @@ public final class AdminSettlementExamples {
           "pgFeeRate": 0.0170,
           "pgFeeRateDisplay": 0.0180,
           "pgFeeRateBaseline": 0.0195,
-          "vatRate": 0.1000
+          "vatRate": 0.1000,
+          "settlementNote": "Payple SUCCESS - code: A0000, message: 승인완료"
         }
       }
       """;
@@ -145,6 +146,55 @@ public final class AdminSettlementExamples {
             "totalElements": 52,
             "first": true,
             "last": false,
+            "empty": false
+          }
+        }
+      }
+      """;
+
+  public static final String PG_FEE_ADJUSTMENTS_SUCCESS_EXAMPLE =
+      """
+      {
+        "success": true,
+        "code": "SUCCESS",
+        "message": "PG 수수료 차액 내역 조회가 성공적으로 처리되었습니다.",
+        "data": {
+          "items": [
+            {
+              "settlementId": 321,
+              "settlementItemId": 654,
+              "purchaseId": 987,
+              "sellerId": 42,
+              "sellerNickname": "groble_maker",
+              "merchantUid": "ORD-20250201-00001",
+              "contentTitle": "AI 툴 개발 가이드",
+              "salesAmount": 150000.00,
+              "pgFeeApplied": 4350.00,
+              "pgFeeDisplay": 2550.00,
+              "pgFeeDifference": 1800.00,
+              "feeVat": 435.00,
+              "feeVatDisplay": 255.00,
+              "feeVatDifference": 180.00,
+              "pgFeeRefundExpected": 1980.00,
+              "totalFee": 4785.00,
+              "totalFeeDisplay": 2805.00,
+              "settlementAmount": 145215.00,
+              "settlementAmountDisplay": 147195.00,
+              "purchasedAt": "2025-02-01 12:34:56",
+              "orderStatus": "PAID",
+              "capturedPgFeeRate": 0.0290,
+              "capturedPgFeeRateDisplay": 0.0170,
+              "capturedPgFeeRateBaseline": 0.0170,
+              "capturedVatRate": 0.1000
+            }
+          ],
+          "pageInfo": {
+            "currentPage": 0,
+            "totalPages": 1,
+            "pageSize": 20,
+            "totalElements": 1,
+            "first": true,
+            "last": true,
             "empty": false
           }
         }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementSwaggerDocs.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/admin/docs/AdminSettlementSwaggerDocs.java
@@ -36,6 +36,7 @@ public final class AdminSettlementSwaggerDocs {
                     **응답 데이터:**
                     - 정산 항목의 상세 정보 포함
                     - 관련된 결제 및 환불 내역 포함
+                    - 페이플 응답 메모(settlementNote) 포함
                     """;
   // === 정산 상세 총 판매 내역 조회 API ===
   public static final String SETTLEMENT_DETAIL_SALES_SUMMARY =
@@ -50,5 +51,21 @@ public final class AdminSettlementSwaggerDocs {
                       **응답 데이터:**
                       - 해당 정산 항목에 포함된 모든 판매 내역 리스트
                       - 각 판매 내역에 대한 상세 정보 포함
+                      """;
+
+  public static final String PG_FEE_ADJUSTMENTS_SUMMARY =
+      "[✅ PG 수수료 차액 내역 조회] 관리자가 PG 2.9%와 기준 1.7% 간 차액을 확인합니다.";
+  public static final String PG_FEE_ADJUSTMENTS_DESCRIPTION =
+      """
+                      관리자가 PG 실제 청구 수수료(2.9%)와 표시 기준(1.7%) 간 차액을 거래 단위로 조회합니다.
+
+                      **요청 파라미터:**
+                      - startDate, endDate: 조회 기간 (선택)
+                      - settlementId: 특정 정산 묶음 필터 (선택)
+                      - sellerId: 판매자 필터 (선택)
+
+                      **응답 데이터:**
+                      - 각 거래별 PG 수수료 차액, VAT 차액, 환급 예상액 정보
+                      - 페이징 정보 포함
                       """;
 }

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ApiPaths.java
@@ -37,6 +37,7 @@ public final class ApiPaths {
     public static final String ALL_USERS_SETTLEMENTS = "/all-users";
     public static final String SETTLEMENT_DETAIL = "/{settlementId}";
     public static final String SALES_LIST = "/sales/{settlementId}";
+    public static final String PG_FEE_ADJUSTMENTS = "/pg-fee-adjustments";
 
     public static final String ORDERS = "/orders";
     public static final String ORDER_CANCEL_REQUEST = "/order/{merchantUid}/cancel-request";

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/ResponseMessages.java
@@ -13,6 +13,7 @@ public final class ResponseMessages {
     public static final String ALL_USERS_SETTLEMENTS_RETRIEVED = "전체 사용자 정산 내역 조회에 성공하였습니다.";
     public static final String SETTLEMENT_DETAIL_RETRIEVED = "사용자 정산 상세 내역 조회에 성공하였습니다.";
     public static final String SALES_LIST_RETRIEVED = "정산별 판매 내역 조회에 성공하였습니다.";
+    public static final String PG_FEE_ADJUSTMENTS_RETRIEVED = "PG 수수료 차액 내역 조회에 성공하였습니다.";
     public static final String USER_SUMMARY_INFO_RETRIEVED = "관리자 전체 사용자 목록 조회에 성공하였습니다.";
     public static final String GUEST_USER_SUMMARY_INFO_RETRIEVED = "관리자 비회원 사용자 목록 조회에 성공하였습니다.";
     public static final String ADMIN_SIGN_IN_SUCCESS = "관리자 로그인에 성공했습니다.";

--- a/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/AdminResponseSchemas.java
+++ b/groble-api/groble-api-server/src/main/java/liaison/groble/api/server/common/swagger/AdminResponseSchemas.java
@@ -7,6 +7,7 @@ import java.util.List;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementDetailResponse;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.PerTransactionAdminSettlementOverviewResponse;
+import liaison.groble.api.model.admin.settlement.response.PgFeeAdjustmentResponse;
 import liaison.groble.api.model.admin.settlement.response.SettlementApprovalResponse;
 import liaison.groble.common.response.GrobleResponse;
 import liaison.groble.common.response.PageResponse;
@@ -54,6 +55,18 @@ public final class AdminResponseSchemas {
     @Override
     @Schema(description = "페이징된 정산 판매 목록", implementation = PageResponse.class)
     public PageResponse<PerTransactionAdminSettlementOverviewResponse> getData() {
+      return super.getData();
+    }
+  }
+
+  /** 관리자 PG 수수료 차액 조회 응답 스키마 */
+  @Schema(description = "관리자 PG 수수료 차액 조회 응답")
+  public static class ApiAdminPgFeeAdjustmentsResponse
+      extends GrobleResponse<PageResponse<PgFeeAdjustmentResponse>> {
+
+    @Override
+    @Schema(description = "페이징된 PG 수수료 차액 목록", implementation = PageResponse.class)
+    public PageResponse<PgFeeAdjustmentResponse> getData() {
       return super.getData();
     }
   }

--- a/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/AdminSettlementDetailDTO.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/AdminSettlementDetailDTO.java
@@ -46,4 +46,5 @@ public class AdminSettlementDetailDTO {
   private BigDecimal pgFeeRateDisplay;
   private BigDecimal pgFeeRateBaseline;
   private BigDecimal vatRate;
+  private String settlementNote;
 }

--- a/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/PgFeeAdjustmentDTO.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/settlement/dto/PgFeeAdjustmentDTO.java
@@ -1,0 +1,37 @@
+package liaison.groble.application.admin.settlement.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PgFeeAdjustmentDTO {
+  private Long settlementId;
+  private Long settlementItemId;
+  private Long purchaseId;
+  private Long sellerId;
+  private String sellerNickname;
+  private String merchantUid;
+  private String contentTitle;
+  private BigDecimal salesAmount;
+  private BigDecimal pgFeeApplied;
+  private BigDecimal pgFeeDisplay;
+  private BigDecimal pgFeeDifference;
+  private BigDecimal feeVat;
+  private BigDecimal feeVatDisplay;
+  private BigDecimal feeVatDifference;
+  private BigDecimal pgFeeRefundExpected;
+  private BigDecimal totalFee;
+  private BigDecimal totalFeeDisplay;
+  private BigDecimal settlementAmount;
+  private BigDecimal settlementAmountDisplay;
+  private LocalDateTime purchasedAt;
+  private String orderStatus;
+  private BigDecimal capturedPgFeeRate;
+  private BigDecimal capturedPgFeeRateDisplay;
+  private BigDecimal capturedPgFeeRateBaseline;
+  private BigDecimal capturedVatRate;
+}

--- a/groble-application/src/main/java/liaison/groble/application/admin/settlement/service/AdminSettlementService.java
+++ b/groble-application/src/main/java/liaison/groble/application/admin/settlement/service/AdminSettlementService.java
@@ -1,6 +1,7 @@
 package liaison.groble.application.admin.settlement.service;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.stream.Collectors;
 import org.json.simple.JSONObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +19,7 @@ import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDT
 import liaison.groble.application.admin.settlement.dto.PaypleAccountVerificationRequest;
 import liaison.groble.application.admin.settlement.dto.PayplePartnerAuthResult;
 import liaison.groble.application.admin.settlement.dto.PerTransactionAdminSettlementOverviewDTO;
+import liaison.groble.application.admin.settlement.dto.PgFeeAdjustmentDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO.FailedSettlementDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO.PaypleSettlementResultDTO;
@@ -26,6 +29,7 @@ import liaison.groble.application.settlement.reader.SettlementReader;
 import liaison.groble.common.response.PageResponse;
 import liaison.groble.domain.settlement.dto.FlatAdminSettlementsDTO;
 import liaison.groble.domain.settlement.dto.FlatPerTransactionSettlement;
+import liaison.groble.domain.settlement.dto.FlatPgFeeAdjustmentDTO;
 import liaison.groble.domain.settlement.entity.Settlement;
 import liaison.groble.domain.settlement.entity.SettlementItem;
 import liaison.groble.domain.settlement.repository.SettlementRepository;
@@ -60,13 +64,7 @@ public class AdminSettlementService {
     List<AdminSettlementOverviewDTO> items =
         page.getContent().stream().map(this::convertFlatDTOToAdminSettlementsDTO).toList();
 
-    PageResponse.MetaData meta =
-        PageResponse.MetaData.builder()
-            .sortBy(pageable.getSort().iterator().next().getProperty())
-            .sortDirection(pageable.getSort().iterator().next().getDirection().name())
-            .build();
-
-    return PageResponse.from(page, items, meta);
+    return PageResponse.from(page, items, buildMetaData(pageable));
   }
 
   @Transactional(readOnly = true)
@@ -100,6 +98,7 @@ public class AdminSettlementService {
         .pgFeeRateDisplay(settlement.getPgFeeRateDisplay())
         .pgFeeRateBaseline(settlement.getPgFeeRateBaseline())
         .vatRate(settlement.getVatRate())
+        .settlementNote(settlement.getSettlementNote())
         .build();
   }
 
@@ -112,13 +111,20 @@ public class AdminSettlementService {
     List<PerTransactionAdminSettlementOverviewDTO> items =
         page.getContent().stream().map(this::convertFlatDTOToPerTransactionDTO).toList();
 
-    PageResponse.MetaData meta =
-        PageResponse.MetaData.builder()
-            .sortBy(pageable.getSort().iterator().next().getProperty())
-            .sortDirection(pageable.getSort().iterator().next().getDirection().name())
-            .build();
+    return PageResponse.from(page, items, buildMetaData(pageable));
+  }
 
-    return PageResponse.from(page, items, meta);
+  @Transactional(readOnly = true)
+  public PageResponse<PgFeeAdjustmentDTO> getPgFeeAdjustments(
+      LocalDate startDate, LocalDate endDate, Long settlementId, Long sellerId, Pageable pageable) {
+
+    Page<FlatPgFeeAdjustmentDTO> page =
+        settlementReader.findPgFeeAdjustments(startDate, endDate, settlementId, sellerId, pageable);
+
+    List<PgFeeAdjustmentDTO> items =
+        page.getContent().stream().map(this::convertFlatDTOToPgFeeAdjustmentDTO).toList();
+
+    return PageResponse.from(page, items, buildMetaData(pageable));
   }
 
   /**
@@ -178,23 +184,30 @@ public class AdminSettlementService {
         }
 
         paypleResult = executePaypleGroupSettlementImmediately(validItemsForPayple);
+        String paypleResponseNote = buildPaypleResponseNote(paypleResult);
 
         // 4. 페이플 정산 성공 시에만 DB 상태를 COMPLETED로 변경
         if (paypleResult != null && paypleResult.isSuccess()) {
           for (Settlement settlement : validSettlements) {
             settlement.completeSettlement(); // 웹훅에서도 호출되지만 즉시 실행이므로 여기서 완료 처리
+            if (paypleResponseNote != null) {
+              settlement.updateSettlementNote(paypleResponseNote);
+            }
             actualApprovedSettlementCount++;
             log.info("정산 최종 승인 완료 - ID: {}", settlement.getId());
           }
         } else {
           log.error("페이플 정산 실패로 인한 정산 승인 취소 - 정산 수: {}", validSettlements.size());
+          String failureNote =
+              paypleResponseNote != null ? paypleResponseNote : "Payple FAILURE - 코드/메시지 없음";
           // 페이플 실패 시 검증된 정산들을 실패 처리
           for (Settlement settlement : validSettlements) {
             settlement.failSettlement(); // 보류 상태로 변경
+            settlement.updateSettlementNote(failureNote);
             failedSettlements.add(
                 FailedSettlementDTO.builder()
                     .settlementId(settlement.getId())
-                    .failureReason("페이플 정산 실행 실패")
+                    .failureReason(failureNote)
                     .build());
           }
           // 성공 카운트들을 0으로 재설정
@@ -551,6 +564,34 @@ public class AdminSettlementService {
         + sensitiveData.substring(sensitiveData.length() - 4);
   }
 
+  private PageResponse.MetaData buildMetaData(Pageable pageable) {
+    String sortBy = "createdAt";
+    String sortDirection = Sort.Direction.DESC.name();
+
+    if (pageable.getSort().isSorted()) {
+      Sort.Order order = pageable.getSort().iterator().next();
+      sortBy = order.getProperty();
+      sortDirection = order.getDirection().name();
+    }
+
+    return PageResponse.MetaData.builder().sortBy(sortBy).sortDirection(sortDirection).build();
+  }
+
+  private String buildPaypleResponseNote(PaypleSettlementResultDTO paypleResult) {
+    if (paypleResult == null) {
+      return null;
+    }
+
+    String status = paypleResult.isSuccess() ? "SUCCESS" : "FAILURE";
+    String responseCode =
+        paypleResult.getResponseCode() != null ? paypleResult.getResponseCode() : "N/A";
+    String responseMessage =
+        paypleResult.getResponseMessage() != null ? paypleResult.getResponseMessage() : "N/A";
+
+    return String.format(
+        "Payple %s - code: %s, message: %s", status, responseCode, responseMessage);
+  }
+
   private AdminSettlementOverviewDTO convertFlatDTOToAdminSettlementsDTO(
       FlatAdminSettlementsDTO flatAdminSettlementsDTO) {
     BigDecimal displayAmount = flatAdminSettlementsDTO.getSettlementAmountDisplay();
@@ -569,6 +610,36 @@ public class AdminSettlementService {
         .bankAccountNumber(flatAdminSettlementsDTO.getBankAccountNumber())
         .copyOfBankbookUrl(flatAdminSettlementsDTO.getCopyOfBankbookUrl())
         .businessLicenseFileUrl(flatAdminSettlementsDTO.getBusinessLicenseFileUrl())
+        .build();
+  }
+
+  private PgFeeAdjustmentDTO convertFlatDTOToPgFeeAdjustmentDTO(FlatPgFeeAdjustmentDTO flat) {
+    return PgFeeAdjustmentDTO.builder()
+        .settlementId(flat.getSettlementId())
+        .settlementItemId(flat.getSettlementItemId())
+        .purchaseId(flat.getPurchaseId())
+        .sellerId(flat.getSellerId())
+        .sellerNickname(flat.getSellerNickname())
+        .merchantUid(flat.getMerchantUid())
+        .contentTitle(flat.getContentTitle())
+        .salesAmount(flat.getSalesAmount())
+        .pgFeeApplied(flat.getPgFeeApplied())
+        .pgFeeDisplay(flat.getPgFeeDisplay())
+        .pgFeeDifference(flat.getPgFeeDifference())
+        .feeVat(flat.getFeeVat())
+        .feeVatDisplay(flat.getFeeVatDisplay())
+        .feeVatDifference(flat.getFeeVatDifference())
+        .pgFeeRefundExpected(flat.getPgFeeRefundExpected())
+        .totalFee(flat.getTotalFee())
+        .totalFeeDisplay(flat.getTotalFeeDisplay())
+        .settlementAmount(flat.getSettlementAmount())
+        .settlementAmountDisplay(flat.getSettlementAmountDisplay())
+        .purchasedAt(flat.getPurchasedAt())
+        .orderStatus(flat.getOrderStatus())
+        .capturedPgFeeRate(flat.getCapturedPgFeeRate())
+        .capturedPgFeeRateDisplay(flat.getCapturedPgFeeRateDisplay())
+        .capturedPgFeeRateBaseline(flat.getCapturedPgFeeRateBaseline())
+        .capturedVatRate(flat.getCapturedVatRate())
         .build();
   }
 

--- a/groble-application/src/main/java/liaison/groble/application/settlement/reader/SettlementReader.java
+++ b/groble-application/src/main/java/liaison/groble/application/settlement/reader/SettlementReader.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import liaison.groble.common.exception.EntityNotFoundException;
 import liaison.groble.domain.settlement.dto.FlatAdminSettlementsDTO;
 import liaison.groble.domain.settlement.dto.FlatPerTransactionSettlement;
+import liaison.groble.domain.settlement.dto.FlatPgFeeAdjustmentDTO;
 import liaison.groble.domain.settlement.dto.FlatSettlementsDTO;
 import liaison.groble.domain.settlement.entity.Settlement;
 import liaison.groble.domain.settlement.entity.SettlementItem;
@@ -106,6 +107,12 @@ public class SettlementReader {
   public Page<FlatPerTransactionSettlement> findSalesListBySettlementId(
       Long settlementId, Pageable pageable) {
     return settlementCustomRepository.findSalesListBySettlementId(settlementId, pageable);
+  }
+
+  public Page<FlatPgFeeAdjustmentDTO> findPgFeeAdjustments(
+      LocalDate startDate, LocalDate endDate, Long settlementId, Long sellerId, Pageable pageable) {
+    return settlementCustomRepository.findPgFeeAdjustments(
+        startDate, endDate, settlementId, sellerId, pageable);
   }
 
   public List<Settlement> findAllByUserId(Long userId) {

--- a/groble-domain/src/main/java/liaison/groble/domain/settlement/dto/FlatPgFeeAdjustmentDTO.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/settlement/dto/FlatPgFeeAdjustmentDTO.java
@@ -1,0 +1,42 @@
+package liaison.groble.domain.settlement.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 정산 항목별 PG 수수료 차액(실제 2.9% - 기준 1.7%)을 조회하기 위한 평탄화 DTO. */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FlatPgFeeAdjustmentDTO {
+  private Long settlementId;
+  private Long settlementItemId;
+  private Long purchaseId;
+  private Long sellerId;
+  private String sellerNickname;
+  private String merchantUid;
+  private String contentTitle;
+  private BigDecimal salesAmount;
+  private BigDecimal pgFeeApplied;
+  private BigDecimal pgFeeDisplay;
+  private BigDecimal pgFeeDifference;
+  private BigDecimal feeVat;
+  private BigDecimal feeVatDisplay;
+  private BigDecimal feeVatDifference;
+  private BigDecimal pgFeeRefundExpected;
+  private BigDecimal totalFee;
+  private BigDecimal totalFeeDisplay;
+  private BigDecimal settlementAmount;
+  private BigDecimal settlementAmountDisplay;
+  private LocalDateTime purchasedAt;
+  private String orderStatus;
+  private BigDecimal capturedPgFeeRate;
+  private BigDecimal capturedPgFeeRateDisplay;
+  private BigDecimal capturedPgFeeRateBaseline;
+  private BigDecimal capturedVatRate;
+}

--- a/groble-domain/src/main/java/liaison/groble/domain/settlement/entity/Settlement.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/settlement/entity/Settlement.java
@@ -659,6 +659,10 @@ public class Settlement extends BaseTimeEntity {
     }
   }
 
+  public void updateSettlementNote(String note) {
+    this.settlementNote = note;
+  }
+
   /** 페이플 이체 결과 정보 업데이트 */
   public void updatePaypleTransferResult(
       String apiTranId,

--- a/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementCustomRepository.java
+++ b/groble-domain/src/main/java/liaison/groble/domain/settlement/repository/SettlementCustomRepository.java
@@ -1,12 +1,14 @@
 package liaison.groble.domain.settlement.repository;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import liaison.groble.domain.settlement.dto.FlatAdminSettlementsDTO;
 import liaison.groble.domain.settlement.dto.FlatPerTransactionSettlement;
+import liaison.groble.domain.settlement.dto.FlatPgFeeAdjustmentDTO;
 import liaison.groble.domain.settlement.dto.FlatSettlementsDTO;
 
 public interface SettlementCustomRepository {
@@ -19,6 +21,9 @@ public interface SettlementCustomRepository {
       Long settlementId, Pageable pageable);
 
   Page<FlatAdminSettlementsDTO> findAdminSettlementsByUserId(Long adminUserId, Pageable pageable);
+
+  Page<FlatPgFeeAdjustmentDTO> findPgFeeAdjustments(
+      LocalDate startDate, LocalDate endDate, Long settlementId, Long sellerId, Pageable pageable);
 
   BigDecimal getTotalCompletedPlatformFee();
 }

--- a/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminSettlementMapper.java
+++ b/groble-mapping/src/main/java/liaison/groble/mapping/admin/AdminSettlementMapper.java
@@ -7,10 +7,12 @@ import liaison.groble.api.model.admin.settlement.request.SettlementApprovalReque
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementDetailResponse;
 import liaison.groble.api.model.admin.settlement.response.AdminSettlementsOverviewResponse;
 import liaison.groble.api.model.admin.settlement.response.PerTransactionAdminSettlementOverviewResponse;
+import liaison.groble.api.model.admin.settlement.response.PgFeeAdjustmentResponse;
 import liaison.groble.api.model.admin.settlement.response.SettlementApprovalResponse;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementDetailDTO;
 import liaison.groble.application.admin.settlement.dto.AdminSettlementOverviewDTO;
 import liaison.groble.application.admin.settlement.dto.PerTransactionAdminSettlementOverviewDTO;
+import liaison.groble.application.admin.settlement.dto.PgFeeAdjustmentDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalDTO;
 import liaison.groble.application.admin.settlement.dto.SettlementApprovalRequestDTO;
 import liaison.groble.common.response.PageResponse;
@@ -40,6 +42,11 @@ public interface AdminSettlementMapper extends PageResponseMapper {
     return toPageResponse(dtoPage, this::toPerTransactionAdminSettlementOverviewResponse);
   }
 
+  default PageResponse<PgFeeAdjustmentResponse> toPgFeeAdjustmentResponsePage(
+      PageResponse<PgFeeAdjustmentDTO> dtoPage) {
+    return toPageResponse(dtoPage, this::toPgFeeAdjustmentResponse);
+  }
+
   AdminSettlementsOverviewResponse toAdminSettlementsOverviewResponse(
       AdminSettlementOverviewDTO adminSettlementOverviewDTO);
 
@@ -48,6 +55,8 @@ public interface AdminSettlementMapper extends PageResponseMapper {
 
   PerTransactionAdminSettlementOverviewResponse toPerTransactionAdminSettlementOverviewResponse(
       PerTransactionAdminSettlementOverviewDTO perTransactionAdminSettlementOverviewDTO);
+
+  PgFeeAdjustmentResponse toPgFeeAdjustmentResponse(PgFeeAdjustmentDTO dto);
 
   /** PaypleSettlementResultDTO 매핑 */
   SettlementApprovalResponse.PaypleSettlementResult toPaypleResult(


### PR DESCRIPTION
- `settlementNote` 처리 로직 추가해서 정산지급대행 실행 후에 메시징 처리
- 페이플 결제 차액 조회 API 추가 
- 기존 데이터 결제 차액 SQL 쿼리 반영